### PR TITLE
Append remaining test of only input video for vlm pipeline.

### DIFF
--- a/tests/python_tests/test_vlm_pipeline.py
+++ b/tests/python_tests/test_vlm_pipeline.py
@@ -420,7 +420,7 @@ def test_images(request: pytest.FixtureRequest):
     pytest.param(["synthetic_video_32x32_tensor"], id="single_video"),
     pytest.param(["synthetic_video_32x32_tensor", "video_frame_3_tensor"], id="multiple_videos"),
 ])
-def test_videos(request: pytest.FixtureRequest):
+def synthetic_video(request: pytest.FixtureRequest):
     return [request.getfixturevalue(video) for video in request.param]
 
 @pytest.mark.precommit


### PR DESCRIPTION
## Description
A separated PR to enable an only video input test case. 

<!--- Jira ticket number (e.g., 123). Delete if there's no ticket. Don't include full link or project name. -->
Ticket: [CVS-173219](https://jira.devtools.intel.com/browse/CVS-173219)

## Checklist:
- [ ] Add remaining test case: only input videos for vlm pipeline.
