### PR TITLE
Make z image denoise module to return 4d tensor

### DIFF
--- a/samples/cpp/module_genai/ut_modules/VAEDecoderModule.cpp
+++ b/samples/cpp/module_genai/ut_modules/VAEDecoderModule.cpp
@@ -18,7 +18,7 @@ pipeline_modules:
     type: "VAEDecoderModule"
     device: "CPU"
     inputs:
-      - name: "latent"
+      - name: "latents"
         type: "OVTensor"
         source: "pipeline_params.latent_input"
     outputs:
@@ -34,7 +34,7 @@ pipeline_modules:
         // Latent shape for VAE decoder usually depends on the model config.
         // The model expects 16 channels (e.g. Z-Image-Turbo).
         // Using a small size for testing.
-        auto latent = ut_randn_tensor(ov::Shape{16, 64, 64}, 42);
+        auto latent = ut_randn_tensor(ov::Shape{1, 16, 64, 64}, 42);
         inputs["latent_input"] = latent;
         return inputs;
     }
@@ -62,7 +62,7 @@ pipeline_modules:
     type: "VAEDecoderModule"
     device: "CPU"
     inputs:
-      - name: "latent"
+      - name: "latents"
         type: "OVTensor"
         source: "pipeline_params.latent_input"
     outputs:
@@ -77,7 +77,7 @@ pipeline_modules:
     ov::AnyMap prepare_inputs() override {
         ov::AnyMap inputs;
 
-        auto latent = ut_randn_tensor(ov::Shape{16, 64, 64}, 42);
+        auto latent = ut_randn_tensor(ov::Shape{1, 16, 64, 64}, 42);
         inputs["latent_input"] = latent;
         return inputs;
     }

--- a/samples/cpp/module_genai/ut_modules/ZImageDenoiserLoopModule.cpp
+++ b/samples/cpp/module_genai/ut_modules/ZImageDenoiserLoopModule.cpp
@@ -27,7 +27,7 @@ pipeline_modules:
       - name: "height"                            # [optional], default 512
         type: "Int"
     outputs:
-      - name: "latent"
+      - name: "latents"
         type: "OVTensor"
     params:
       model_path: "./ut_pipelines/Z-Image-Turbo-fp16-ov/"
@@ -46,7 +46,7 @@ pipeline_modules:
     }
 
     void verify_outputs(ov::genai::module::ModulePipeline& pipe) override {
-        auto output = pipe.get_output("latent").as<ov::Tensor>();
+        auto output = pipe.get_output("latents").as<ov::Tensor>();
         std::vector<float> expected_ouput = { 
           0.0279331, -0.0194968, -0.158097, 0.142582, -0.313633, -0.452601, 0.107033, 0.305759, -0.0610831, 0.136313
         };

--- a/samples/python/module_genai/module_pipeline_z_image.py
+++ b/samples/python/module_genai/module_pipeline_z_image.py
@@ -91,7 +91,7 @@ class TransformerPipeline():
                     ],
                     'outputs': [
                         {
-                            'name': 'latent',
+                            'name': 'latents',
                             'type': 'OVTensor'
                         }
                     ],
@@ -105,9 +105,9 @@ class TransformerPipeline():
                     'description': 'Z-Image denoiser loop.',
                     'inputs': [
                         {
-                            'name': 'latent',
+                            'name': 'latents',
                             'type': 'OVTensor',
-                            'source': 'denoiser_loop.latent',
+                            'source': 'denoiser_loop.latents',
                         }
                     ],
                     'outputs': [

--- a/src/cpp/src/module_genai/modules/md_vae_decoder.cpp
+++ b/src/cpp/src/module_genai/modules/md_vae_decoder.cpp
@@ -15,7 +15,7 @@ void VAEDecoderModule::print_static_config() {
   - name: "VAE_decoder"
     type: "VAEDecoderModule"
     inputs:
-      - name: "latent"
+      - name: "latents"
         type: "OVTensor"
     outputs:
       - name: "image"
@@ -81,13 +81,13 @@ void VAEDecoderModule::run() {
 
     prepare_inputs();
     
-    if (this->inputs.find("latent") == this->inputs.end()) {
-        GENAI_ERR("VAEDecoderModule[" + module_desc->name + "]: 'latent' input not found");
+    if (this->inputs.find("latents") == this->inputs.end()) {
+        GENAI_ERR("VAEDecoderModule[" + module_desc->name + "]: 'latents' input not found");
         return;
     }
 
-    ov::Tensor latent = tensor_utils::unsqueeze(this->inputs["latent"].data.as<ov::Tensor>(), 0);
-    ov::Tensor image = m_vae->decode(latent);
+    ov::Tensor latents = this->inputs["latents"].data.as<ov::Tensor>();
+    ov::Tensor image = m_vae->decode(latents);
 
     this->outputs["image"].data = image;
 }

--- a/src/cpp/src/module_genai/modules/md_zimage_denoiser_loop.cpp
+++ b/src/cpp/src/module_genai/modules/md_zimage_denoiser_loop.cpp
@@ -51,7 +51,7 @@ void ZImageDenoiserLoopModule::print_static_config() {
         source: "ParentModuleName.OutputPortName"
     outputs:
       - name: "latents"
-        type: "OVTensor"                                   # Support DataType: [VecOVTensor]
+        type: "OVTensor"                                   # Support DataType: [OVTensor]
     params:
       model_path: "model"
     )" << std::endl;

--- a/src/cpp/src/module_genai/modules/md_zimage_denoiser_loop.cpp
+++ b/src/cpp/src/module_genai/modules/md_zimage_denoiser_loop.cpp
@@ -50,10 +50,8 @@ void ZImageDenoiserLoopModule::print_static_config() {
         type: "Float"                                      # Support DataType: [Int]
         source: "ParentModuleName.OutputPortName"
     outputs:
-      - name: "latent"
-        type: "OVTensor"                                   # Support DataType: [VecOVTensor]
       - name: "latents"
-        type: "VecOVTensor"                                   # Support DataType: [VecOVTensor]
+        type: "OVTensor"                                   # Support DataType: [VecOVTensor]
     params:
       model_path: "model"
     )" << std::endl;
@@ -175,20 +173,15 @@ void ZImageDenoiserLoopModule::run() {
     } else {
         generation_config.guidance_scale = 1.0f;
     }
-    auto outputs = run(prompt_embeds, negative_prompt_embeds, generation_config);
-    if (m_is_multi_prompts) {
-        this->outputs["latents"].data = outputs;
-    } else {
-        this->outputs["latent"].data = outputs[0];
-    }
+    this->outputs["latents"].data = run(prompt_embeds, negative_prompt_embeds, generation_config);
 }
 
-std::vector<ov::Tensor> ZImageDenoiserLoopModule::run(
+ov::Tensor ZImageDenoiserLoopModule::run(
         const std::vector<ov::Tensor>& prompt_embeds,
         const std::vector<ov::Tensor>& negative_prompt_embeds,
         const ImageGenerationConfig &generation_config) {
     // TODO: Add multi image support and negative prompt support
-    int batch_size = prompt_embeds.size();
+    size_t batch_size = prompt_embeds.size();
     int num_channels_latents = m_transformer_config.in_channels;
     ov::Tensor latents = prepare_latents(
         batch_size * generation_config.num_images_per_prompt, 
@@ -217,7 +210,6 @@ std::vector<ov::Tensor> ZImageDenoiserLoopModule::run(
         }
     }
 
-    int image_seq_len = (latents.get_shape().at(2) / 2) * (latents.get_shape().at(3) / 2);
     m_scheduler->set_timesteps(
         generation_config.num_inference_steps,
          generation_config.strength);
@@ -242,14 +234,14 @@ std::vector<ov::Tensor> ZImageDenoiserLoopModule::run(
             noise_pred, latents, inference_step, generation_config.generator);
         latents = scheduler_step_result["latent"];
     }
-    return tensor_utils::split(latents);
+    return latents;
 }
 
 ov::Tensor ZImageDenoiserLoopModule::prepare_latents(
-        int batch_size,
+        size_t batch_size,
         int num_channels,
-        int width,
-        int height,
+        size_t width,
+        size_t height,
         element::Type element_type,
         std::shared_ptr<Generator> generator) {
     height = 2 * (height / (m_vae_scale_factor * 2));

--- a/src/cpp/src/module_genai/modules/md_zimage_denoiser_loop.hpp
+++ b/src/cpp/src/module_genai/modules/md_zimage_denoiser_loop.hpp
@@ -33,18 +33,17 @@ public:
 private:
     bool initialize();
     int get_vae_scale_factor(const std::filesystem::path &model_path) const;
-    std::vector<ov::Tensor> run(
+    ov::Tensor run(
         const std::vector<ov::Tensor>& prompt_embeds,
         const std::vector<ov::Tensor>& negative_prompt_embeds,
         const ImageGenerationConfig &generation_config);
     ov::Tensor prepare_latents(
-        int batch_size,
+        size_t batch_size,
         int num_channels,
-        int height,
-        int width,
+        size_t width,
+        size_t height,
         element::Type element_type,
         std::shared_ptr<Generator> generator);
-    ov::Tensor stack(const std::vector<ov::Tensor>& tensors);
     ImageGenerationModelType m_model_type;
     TransformerConfig m_transformer_config;
     std::unique_ptr<IScheduler> m_scheduler;


### PR DESCRIPTION
## Main Change:
1. Make z image denoise module to return 4d tensor.

## Test Result:
<img width="427" height="582" alt="module uint test result" src="https://github.com/user-attachments/assets/33c4ecf2-3c81-4cd2-9044-98c105e2a1f4" />

<img width="512" height="512" alt="zimage_denoiser_loop_output-vae" src="https://github.com/user-attachments/assets/28b83d08-e2ef-4020-a9b9-4267fe8d3c14" />

