### PR TITLE
vae_decoder_tiling: fix build issue.

### DIFF
--- a/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.cpp
+++ b/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.cpp
@@ -116,7 +116,8 @@ bool VAEDecoderTilingModule::init_post_process() {
     auto added_0_5 = std::make_shared<ov::op::v1::Add>(scaled_0_5, constant_0_5);
     auto clamped = std::make_shared<ov::op::v0::Clamp>(added_0_5, 0.0f, 1.0f);
     auto multiplied = std::make_shared<ov::op::v1::Multiply>(clamped, constant_255);
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{multiplied}, ov::ParameterVector{input});
+    auto result = std::make_shared<ov::op::v0::Result>(multiplied);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
 
     ov::preprocess::PrePostProcessor ppp(model);
     ppp.output().postprocess().convert_element_type(ov::element::u8);


### PR DESCRIPTION
/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.cpp:119:45:   required from here
/usr/include/c++/13/bits/stl_construct.h:119:7: error: no matching function for call to
‘ov::Model::Model(std::vector<std::shared_ptr<ov::Node> >, std::vector<std::shared_ptr<ov::op::v0::Parameter> >)’
  119 |       ::new((void*)__p) _Tp(std::forward<_Args>(__args)...);

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
