### PR TITLE
Enable tiling size param

### DIFF
--- a/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.cpp
+++ b/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.cpp
@@ -42,6 +42,7 @@ void VAEDecoderTilingModule::print_static_config() {
         type: "VecOVTensor"                                # Support DataType: [VecOVTensor]
     params:
       tile_overlap_factor: "0.25"   # [Optional] float, default is 0.25
+      sample_size: "1024"           # [Optional] int, tiling size. default is 1024, 
       model_path: "model"
       sub_module_name: "sub_modules: name"  # sub-pipeline module name
 
@@ -63,18 +64,28 @@ VAEDecoderTilingModule::VAEDecoderTilingModule(const IBaseModuleDesc::PTR& desc,
 VAEDecoderTilingModule::~VAEDecoderTilingModule() {}
 
 bool VAEDecoderTilingModule::init_tile_params(const std::filesystem::path& model_path) {
-    const auto& params = module_desc->params;
-    auto it_tile_overlap = params.find("tile_overlap_factor");
-    if (it_tile_overlap != params.end()) {
-        m_tile_overlap_factor = std::stof(it_tile_overlap->second);
+    auto factor = get_optional_param("tile_overlap_factor");
+    if (!factor.empty()) {
+        m_tile_overlap_factor = std::stof(factor);
     }
+
+    bool have_sample_size = false;
+    auto sample_size = get_optional_param("sample_size");
+    if (!sample_size.empty()) {
+        m_sample_size = std::stoi(sample_size);
+        m_tile_sample_min_size = m_sample_size;
+        have_sample_size = true;
+    }
+
 
     auto config_path = model_path / "vae_decoder/config.json";
     if (std::filesystem::exists(config_path)) {
         std::ifstream vae_config(config_path);
         nlohmann::json parsed = nlohmann::json::parse(vae_config);
-        ov::genai::utils::read_json_param(parsed, "sample_size", m_sample_size);
-        m_tile_sample_min_size = m_sample_size;
+        if (!have_sample_size) {
+            ov::genai::utils::read_json_param(parsed, "sample_size", m_sample_size);
+            m_tile_sample_min_size = m_sample_size;
+        }
 
         // get block_out_channels: "block_out_channels": [128,256,512,512]
         std::vector<int> block_out_channels;
@@ -182,9 +193,10 @@ void VAEDecoderTilingModule::run() {
             tile_decode(cur_latent, output_latent);
         } else {
             // Non-tiling decode
-            std::cout << "VAEDecoderTilingModule[" + module_desc->name + "]: Non-tiling decode for latent shape: " +
-                             ov::genai::module::tensor_utils::shape_to_string(cur_latent.get_shape())
-                      << std::endl;
+            GENAI_WARN("VAEDecoderTilingModule[" + module_desc->name + "]: Latent size w,h [" +
+                       std::to_string(cur_latent.get_shape()[3]) + "," + std::to_string(cur_latent.get_shape()[2]) +
+                       "] is smaller than tile size[" + std::to_string(m_tile_latent_min_size) +
+                       "], using non-tiling decode.");
             output_latent = decoder(cur_latent);
         }
 

--- a/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.hpp
+++ b/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.hpp
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <map>
+#include <memory>
+
+#include "circular_buffer_queue.hpp"
 #include "module_genai/module.hpp"
 #include "module_genai/pipeline_impl.hpp"
 #include "module_genai/transformer_config.hpp"
 #include "openvino/genai/image_generation/generation_config.hpp"
-#include "circular_buffer_queue.hpp"
-#include <memory>
-#include <map>
 
 namespace ov {
 namespace genai {
@@ -28,7 +29,7 @@ private:
 
     ov::InferRequest pp_infer_request;
     bool init_post_process();
-    
+
     ImageGenerationModelType m_model_type;
     float m_tile_overlap_factor = 0.25f;
     int m_sample_size;
@@ -43,6 +44,6 @@ private:
     ov::Tensor blend_h(ov::Tensor& tile1, ov::Tensor& tile2, size_t blend_extent);
 };
 
-}
-}
-}
+}  // namespace module
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.hpp
+++ b/src/cpp/src/module_genai/modules/md_vae_decoder_tiling.hpp
@@ -1,15 +1,12 @@
-// Copyright (C) 2023-2025 Intel Corporation
+// Copyright (C) 2023-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <map>
 #include <memory>
 
-#include "circular_buffer_queue.hpp"
 #include "module_genai/module.hpp"
 #include "module_genai/pipeline_impl.hpp"
 #include "module_genai/transformer_config.hpp"
-#include "openvino/genai/image_generation/generation_config.hpp"
 
 namespace ov {
 namespace genai {

--- a/tests/module_genai/cpp/modules/VAEDecoderTilingModule.cpp
+++ b/tests/module_genai/cpp/modules/VAEDecoderTilingModule.cpp
@@ -8,24 +8,28 @@
 
 // Define test parameters:
 // std::string: device;
-using test_params = std::tuple<std::string>;
+// int: tile_size(sample_size);
+using test_params = std::tuple<std::string, int>;
 using namespace ov::genai::module;
 
 class VAEDecoderTilingModuleTest : public ModuleTestBase, public ::testing::TestWithParam<test_params> {
 private:
     std::string _device;
+    int _tile_size;
 
 public:
     static std::string get_test_case_name(const testing::TestParamInfo<test_params>& obj) {
         const auto& device = std::get<0>(obj.param);
+        int tile_size = std::get<1>(obj.param);
         std::string result;
         result += device;
+        result += "_TileSize_" + std::to_string(tile_size);
         return result;
     }
 
     void SetUp() override {
         REGISTER_TEST_NAME();
-        std::tie(_device) = GetParam();
+        std::tie(_device, _tile_size) = GetParam();
     }
 
     void TearDown() override {}
@@ -48,6 +52,7 @@ protected:
             cur_node["outputs"].push_back(output_node("image", to_string(DataType::OVTensor)));
             cur_node["params"] = YAML::Node();
             cur_node["params"]["tile_overlap_factor"] = "0.25";
+            cur_node["params"]["sample_size"] = std::to_string(_tile_size);
             cur_node["params"]["model_path"] = TEST_MODEL::ZImage_Turbo_fp16_ov();
             cur_node["params"]["sub_module_name"] = vae_decoder_tiling_submodule_name;
             pipeline_modules[vae_decoder_tiling_name] = cur_node;
@@ -80,7 +85,7 @@ protected:
 
     ov::AnyMap prepare_inputs() override {
         ov::AnyMap inputs;
-        auto latent = ut_randn_tensor(ov::Shape{1, 16, 240, 240}, 42);
+        auto latent = ut_randn_tensor(ov::Shape{1, 16, 15, 15}, 42);
         inputs["latent"] = latent;
         return inputs;
     }
@@ -89,8 +94,15 @@ protected:
         auto output = pipe.get_output("image").as<ov::Tensor>();
         EXPECT_EQ(output.get_element_type(), ov::element::u8) << "Expect output data type is u8";
 
-        const std::vector<uint8_t> expected_output = {119, 113, 97, 107, 97, 81, 106, 93};
-        EXPECT_TRUE(compare_big_tensor<uint8_t>(output, expected_output, static_cast<uint8_t>(1))) << "latent do not match expected values";
+        const std::vector<uint8_t> expected_output_1 = {186, 193, 169, 187, 189, 164, 182, 182};
+        const std::vector<uint8_t> expected_output_2 = {190, 198, 173, 189, 192, 165, 183, 183};
+        if (_tile_size == 64) {
+            EXPECT_TRUE(compare_big_tensor<uint8_t>(output, expected_output_1, static_cast<uint8_t>(1)))
+                << "latent do not match expected values";
+        } else {
+            EXPECT_TRUE(compare_big_tensor<uint8_t>(output, expected_output_2, static_cast<uint8_t>(1)))
+                << "latent do not match expected values";
+        }
     }
 };
 
@@ -99,8 +111,9 @@ TEST_P(VAEDecoderTilingModuleTest, ModuleTest) {
 }
 
 static auto test_devices = std::vector<std::string>{TEST_MODEL::get_device()};
+static auto test_tile_sizes = std::vector<int>{64, 1024};
 
 INSTANTIATE_TEST_SUITE_P(ModuleTestSuite,
                          VAEDecoderTilingModuleTest,
-                         ::testing::Combine(::testing::ValuesIn(test_devices)),
+                         ::testing::Combine(::testing::ValuesIn(test_devices), ::testing::ValuesIn(test_tile_sizes)),
                          VAEDecoderTilingModuleTest::get_test_case_name);


### PR DESCRIPTION
1: Enable input tile_size via param.
2: update VAEDecoderTilingModuleTest, reducing input latent size to speed up test.