### PR TITLE
fix PR79 module naming issue

### DIFF
--- a/src/cpp/src/module_genai/comfyui/comfyui.hpp
+++ b/src/cpp/src/module_genai/comfyui/comfyui.hpp
@@ -329,11 +329,11 @@ struct ConversionOptions {
  * Converts ComfyUI API JSON files to OpenVINO GenAI modular pipeline YAML configuration.
  *
  * A Sample ZImage Mapping rules as example:
- * - KSampler (node 3) -> ZImageDenoiserLoopModule
+ * - KSampler (node 3) -> DenoiserLoopModule
  * - CLIPTextEncode (nodes 6, 7) -> ClipTextEncoderModule
  * - SaveImage (node 9) -> SaveImageModule
  * - EmptySD3LatentImage (node 13) -> RandomLatentImageModule (width, height)
- * - UNETLoader (node 16) -> ZImageDenoiserLoopModule params.model_path
+ * - UNETLoader (node 16) -> DenoiserLoopModule params.model_path
  * - VAELoader (node 17) -> VAEDecoderModule params.model_path
  * - CLIPLoader (node 18) -> ClipTextEncoderModule params.model_path
  * - VAEDecodeSwitcher (node 28) -> VAEDecoderTilingModule

--- a/src/cpp/src/module_genai/comfyui/yaml_module_generators.cpp
+++ b/src/cpp/src/module_genai/comfyui/yaml_module_generators.cpp
@@ -62,7 +62,7 @@ void YamlModuleGeneratorRegistry::initialize_defaults() {
     static const std::vector<std::pair<std::string, std::shared_ptr<YamlModuleGeneratorBase>>> default_generators = {
         {"EmptySD3LatentImage",  std::make_shared<RandomLatentImageModuleGenerator>()},
         {"CLIPTextEncode",       std::make_shared<ClipTextEncoderModuleGenerator>()},
-        {"KSampler",             std::make_shared<ZImageDenoiserLoopModuleGenerator>()},
+        {"KSampler",             std::make_shared<DenoiserLoopModuleGenerator>()},
         {"VAEDecode",            std::make_shared<VAEDecoderModuleGenerator>()},
         {"VAEDecodeSwitcher",    std::make_shared<VAEDecoderTilingModuleGenerator>()},
         {"SaveImage",            std::make_shared<SaveImageModuleGenerator>()},
@@ -168,11 +168,11 @@ void ClipTextEncoderModuleGenerator::generate(YamlGeneratorContext& ctx) {
 }
 
 // ============================================================================
-// ZImageDenoiserLoopModule Generator (KSampler)
+// DenoiserLoopModule Generator (KSampler)
 // ============================================================================
 
-void ZImageDenoiserLoopModuleGenerator::generate(YamlGeneratorContext& ctx) {
-    // KSampler -> ZImageDenoiserLoopModule
+void DenoiserLoopModuleGenerator::generate(YamlGeneratorContext& ctx) {
+    // KSampler -> DenoiserLoopModule
     const auto& node = ctx.current_node;
     GENAI_DEBUG("[KSampler] Processing node: node_id_str=%s, title=%s",
                 node.node_id_str.c_str(), node.title.c_str());
@@ -196,7 +196,7 @@ void ZImageDenoiserLoopModuleGenerator::generate(YamlGeneratorContext& ctx) {
     }
 
     std::string module_name = node.node_id_str;
-    GENAI_DEBUG("[YAML] Adding ZImageDenoiserLoopModule (%s)", module_name.c_str());
+    GENAI_DEBUG("[YAML] Adding DenoiserLoopModule (%s)", module_name.c_str());
 
     YAML::Node module = ctx.pipeline_modules[module_name];
     module["device"] = ctx.options.device;
@@ -221,7 +221,7 @@ void ZImageDenoiserLoopModuleGenerator::generate(YamlGeneratorContext& ctx) {
     module["outputs"] = outputs;
 
     module["params"]["model_path"] = ctx.options.model_path;
-    module["type"] = "ZImageDenoiserLoopModule";
+    module["type"] = "DenoiserLoopModule";
 }
 
 // ============================================================================

--- a/src/cpp/src/module_genai/comfyui/yaml_module_generators.hpp
+++ b/src/cpp/src/module_genai/comfyui/yaml_module_generators.hpp
@@ -91,9 +91,9 @@ public:
 };
 
 /**
- * @brief Generator for KSampler -> ZImageDenoiserLoopModule
+ * @brief Generator for KSampler -> DenoiserLoopModule
  */
-class ZImageDenoiserLoopModuleGenerator : public YamlModuleGeneratorBase {
+class DenoiserLoopModuleGenerator : public YamlModuleGeneratorBase {
 public:
     void generate(YamlGeneratorContext& ctx) override;
 };


### PR DESCRIPTION
change the comfyui code per PR79 change: ZImageDenoiserLoopModule->DenoiserLoopModule

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
