### PR TITLE
remove WA wan 2.1 GPU T5 inference issue.

### DIFF
--- a/src/cpp/src/module_genai/comfyui/yaml_module_generators.cpp
+++ b/src/cpp/src/module_genai/comfyui/yaml_module_generators.cpp
@@ -177,14 +177,7 @@ void ClipTextEncoderModuleGenerator::generate(YamlGeneratorContext& ctx) {
                 module_name.c_str(), is_negative ? "negative" : "positive");
 
     YAML::Node module = ctx.pipeline_modules[module_name];
-    // Force CPU for T5/UMT5 text encoders in Wan 2.1 models to avoid NaN issues on GPU
-    // GPU inference of T5 models may produce NaN outputs on some hardware
-    if (ctx.model_type == "wan2.1") {
-        std::cout << "[WARNING] [ClipTextEncoderModule] Forcing CPU device for Wan 2.1 T5 text encoder to avoid NaN issues on GPU" << std::endl;
-        module["device"] = "CPU";
-    } else {
-        module["device"] = ctx.options.device;
-    }
+    module["device"] = ctx.options.device;
 
     YAML::Node inputs;
     if (is_negative) {

--- a/src/cpp/src/module_genai/modules/md_clip_text_encoder.cpp
+++ b/src/cpp/src/module_genai/modules/md_clip_text_encoder.cpp
@@ -118,10 +118,20 @@ bool ClipTextEncoderModule::initialize() {
             // Load and compile text encoder model
             try {
                 auto model = utils::singleton_core().read_model(text_encoder_path);
+
+                // Set compile properties based on model type and device
+                ov::AnyMap compile_properties = {};
+                if (model_type == DiffusionModelType::WAN_2_1 && device.find("GPU") != std::string::npos) {
+                    // Force FP32 precision on GPU for Wan 2.1 T5 encoder to avoid NaN issues
+                    // NOTE: First compilation may take several minutes due to GPU JIT
+                    compile_properties[ov::hint::inference_precision.name()] = ov::element::f32;
+                    GENAI_INFO("Wan 2.1 T5 encoder: Compiling for GPU with FP32 precision (may take a few minutes on first run)...");
+                }
+
                 resources->compiled_model = utils::singleton_core().compile_model(
                     model,
                     device,
-                    ov::AnyMap{});
+                    compile_properties);
             } catch (const std::exception& e) {
                 GENAI_ERR("ClipTextEncoderModule: Failed to load text encoder model: " + std::string(e.what()));
                 return nullptr;


### PR DESCRIPTION
this issue is root caused: the model is should be f32 and inference precision is f32. otherwise, nan issue happen and the output video will be full of white frames

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
