### PR TITLE
windows build issue fix: convert filesystem::path to string in CSplit…

### DIFF
--- a/src/cpp/src/module_genai/modules/md_denoiser_loop/class.cpp
+++ b/src/cpp/src/module_genai/modules/md_denoiser_loop/class.cpp
@@ -110,7 +110,7 @@ bool DenoiserLoopModule::initialize() {
     }
 
     if (m_splitted_model) {
-        m_splitted_model_infer = CSplittedModelInfer::create(transformer_model_path,
+        m_splitted_model_infer = CSplittedModelInfer::create(transformer_model_path.string(),
                                                              module_desc->device,
                                                              m_dynamic_load_weights,
                                                              properties);


### PR DESCRIPTION
…tedModelInfer::create call

fix type mismatch:
CSplittedModelInfer::create expects const std::string& but transformer_model_path is std::filesystem::path. Added .string() conversion to fix MSVC C2664 error.

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
