### PR TITLE
rename ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS - > ENABLE_DYNAMIC_WEIGHT_MA…

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -10,7 +10,7 @@ option(ENABLE_TESTS "Enable tests build" ON)
 option(ENABLE_TOOLS "Enable tools build" ON)
 option(ENABLE_GGUF "Enable support for GGUF format" ON)
 option(ENABLE_XGRAMMAR "Enable support for structured output generation with xgrammar backend" ON)
-option(ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS "Enable offloading model weights (load/release)" OFF)
+option(ENABLE_DYNAMIC_WEIGHT_MANAGEMENT "Enable offloading model weights (load/release)" OFF)
 
 # Disable building samples for NPM package
 if(CPACK_GENERATOR STREQUAL "NPM")

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -146,8 +146,8 @@ if(ENABLE_GGUF)
     target_compile_definitions(${TARGET_NAME_OBJ} PRIVATE ENABLE_GGUF)
 endif()
 
-if(ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS)
-    target_compile_definitions(${TARGET_NAME_OBJ} PRIVATE ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS=1)
+if(ENABLE_DYNAMIC_WEIGHT_MANAGEMENT)
+    target_compile_definitions(${TARGET_NAME_OBJ} PRIVATE ENABLE_DYNAMIC_WEIGHT_MANAGEMENT=1)
 endif()
 
 target_include_directories(${TARGET_NAME_OBJ} SYSTEM PRIVATE "${safetensors.h_SOURCE_DIR}")

--- a/src/cpp/src/module_genai/modules/md_denoiser_loop/splitted_model_infer.cpp
+++ b/src/cpp/src/module_genai/modules/md_denoiser_loop/splitted_model_infer.cpp
@@ -15,10 +15,10 @@ CSplittedModelInfer::CSplittedModelInfer(const std::string& model_path,
     : m_dynamic_load_model_weights(dynamic_load_model_weights),
       m_is_gpu(device.find("GPU") != std::string::npos || device.find("gpu") != std::string::npos),
       m_properties(properties) {
-#ifndef ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#ifndef ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
     OPENVINO_ASSERT(!m_dynamic_load_model_weights,
                     "Dynamic loading of model weights is not enabled in this build. Please set "
-                    "ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS to 1 and rebuild.");
+                    "ENABLE_DYNAMIC_WEIGHT_MANAGEMENT to 'ON' and rebuild.");
 #endif
 
     if (m_dynamic_load_model_weights) {
@@ -89,8 +89,7 @@ void CSplittedModelInfer::get_splitted_model_paths(const std::string& model_path
 void CSplittedModelInfer::load_model(const std::string& model_path,
                                      const ov::AnyMap& properties,
                                      const std::string& device) {
-#if USE_FULL_MODEL
-#else
+#if !USE_FULL_MODEL
     {
         auto model = utils::singleton_core().read_model(m_preprocess_model_path);
         m_preprocess_compiled_model = utils::singleton_core().compile_model(model, device, properties);
@@ -119,7 +118,7 @@ void CSplittedModelInfer::load_model(const std::string& model_path,
                 properties_splitted_model[ov::weights_path.name()] =
                     std::filesystem::path(path).replace_extension(".bin").string();
                 auto cm = utils::singleton_core().compile_model(model, m_context, properties_splitted_model);
-#    ifdef ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#    ifdef ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
                 // Release model weights after compilation to save GPU memory. Load weights again in infer() when
                 // weights are needed.
                 cm.release_model_weights();
@@ -163,7 +162,7 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
     OPENVINO_ASSERT(num_splitted_models > 1,
                     "Splitted models should be at least 2, but got " + std::to_string(num_splitted_models));
 
-#    ifdef ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#    ifdef ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
 #        if ENABLE_MULTIPLE_THREAD_LOAD_MODEL_WEIGHT
     std::future<bool> future_flag;
     if (m_dynamic_load_model_weights) {
@@ -175,7 +174,7 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
         m_compiled_models[0].load_model_weights();
     }
 #        endif  // ENABLE_MULTIPLE_THREAD_LOAD_MODEL_WEIGHT
-#    endif      // ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#    endif      // ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
 
     // Preprocess
     for (const auto& input : inputs) {
@@ -209,7 +208,7 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
         PROFILE(pm, "splitted_model_infer_" + std::to_string(i));
         ov::InferRequest curInferRequest;
         if (m_dynamic_load_model_weights) {
-#    ifdef ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#    ifdef ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
             if (i + 1 < num_splitted_models) {
 #        if ENABLE_MULTIPLE_THREAD_LOAD_MODEL_WEIGHT
                 next_future_flag = thread_utils::load_model_weights_async(m_compiled_models[i + 1]);
@@ -222,7 +221,7 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
                 future_flag.wait();
 #        endif  // ENABLE_MULTIPLE_THREAD_LOAD_MODEL_WEIGHT
             curInferRequest = m_compiled_models[i].create_infer_request();
-#    endif      // ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#    endif      // ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
         } else {
             curInferRequest = m_infer_requests[i];
         }
@@ -238,7 +237,7 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
             curInferRequest.infer();
         }
 
-#    ifdef ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#    ifdef ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
         if (m_dynamic_load_model_weights) {
 #        if ENABLE_MULTIPLE_THREAD_LOAD_MODEL_WEIGHT
             auto release_future =
@@ -256,7 +255,7 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
 #        if ENABLE_MULTIPLE_THREAD_LOAD_MODEL_WEIGHT
         future_flag = std::move(next_future_flag);
 #        endif
-#    endif  // ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#    endif  // ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
     }
 
     GENAI_DEBUG(

--- a/src/cpp/src/module_genai/utils/thread_helper.hpp
+++ b/src/cpp/src/module_genai/utils/thread_helper.hpp
@@ -16,7 +16,7 @@ namespace ov::genai::module::thread_utils {
 #    define ENABLE_MULTIPLE_THREAD_LOAD_MODEL_WEIGHT 0  // Current multiple threads may cause GPU crash.
 #endif
 
-#ifdef ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#ifdef ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
 inline std::future<bool> load_model_weights_async(ov::CompiledModel compiled_model) {
     auto load_fun = [compiled_model]() mutable -> bool {
         PROFILE(pm, "load_model_weights async");

--- a/tests/module_genai/cpp/modules/DenoiserLoopModule.cpp
+++ b/tests/module_genai/cpp/modules/DenoiserLoopModule.cpp
@@ -58,7 +58,7 @@ std::vector<DenoiserLoopTestData> denoiser_loop_test_data() {
     wan_data_splitted_model.splitted_model = true;
     datas.push_back(wan_data_splitted_model);
 
-#ifdef ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS
+#ifdef ENABLE_DYNAMIC_WEIGHT_MANAGEMENT
     // Dynamic load weights for Split model
     DenoiserLoopTestData wan_data_dyn_weights = wan_data;
     wan_data_dyn_weights.splitted_model = true;


### PR DESCRIPTION
This pull request standardizes the naming of the dynamic model weight management feature across the codebase, replacing all instances of `ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS` with `ENABLE_DYNAMIC_WEIGHT_MANAGEMENT`. This affects CMake configuration, preprocessor directives, and related documentation, ensuring consistency and clarity for developers enabling or using this feature.

**CMake and Build System Updates:**
* Renamed the CMake option from `ENABLE_DYNAMIC_LOAD_MODEL_WEIGHTS` to `ENABLE_DYNAMIC_WEIGHT_MANAGEMENT` in `cmake/features.cmake`, and updated all related conditional logic in `src/cpp/CMakeLists.txt` to use the new name. [[1]](diffhunk://#diff-dd9d470bfd7d5c3c875bd6f1c182ac653ef5fb312ae28c24b8ea39c5074e7c8eL13-R13) [[2]](diffhunk://#diff-e3052ec6d01ba5f9ae8d014fd3bdd8653f7e759e704a77bbfdb99ada532923daL149-R150)

**Source Code and Preprocessor Directives:**
* Updated all preprocessor checks and error messages in `splitted_model_infer.cpp` to use `ENABLE_DYNAMIC_WEIGHT_MANAGEMENT` instead of the old name, including assertions, conditional compilation, and feature-specific logic. [[1]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L18-R21) [[2]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L122-R121) [[3]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L166-R165) [[4]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L178-R177) [[5]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L212-R211) [[6]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L225-R224) [[7]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L241-R240) [[8]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L259-R258)
* Changed the preprocessor directive in `thread_helper.hpp` to use the new macro for enabling asynchronous model weight loading.

**Testing:**
* Updated test code in `DenoiserLoopModule.cpp` to check for `ENABLE_DYNAMIC_WEIGHT_MANAGEMENT` instead of the previous macro.

**Other Minor Fixes:**
* Corrected logic in `splitted_model_infer.cpp` for model loading to use `#if !USE_FULL_MODEL` instead of an empty `#else` block, improving code clarity.…NAGEMENT