### PR TITLE
windows build regression fix: multiple compilation errors under MSVC C++17

### DIFF
--- a/src/cpp/src/modeling/models/qwen3_5/processing_qwen3_5.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/processing_qwen3_5.cpp
@@ -1414,7 +1414,6 @@ Qwen3_5VisionInputs Qwen3_5VisionPreprocessor::preprocess(const ov::Tensor& imag
         }
 
         std::vector<float> frame = std::vector<float>(channels * out_h * out_w);
-        float* frame_ptr = frame.data();
         resize_bilinear_to_chw(src_img,
                                in_h,
                                in_w,
@@ -1424,7 +1423,7 @@ Qwen3_5VisionInputs Qwen3_5VisionPreprocessor::preprocess(const ov::Tensor& imag
                                out_w,
                                preprocess_cfg_.image_mean,
                                preprocess_cfg_.image_std,
-                               frame_ptr);
+                               frame);
 
         const size_t frames = 1;
         size_t padded_frames = frames;

--- a/src/cpp/src/module_genai/modules/model/qwen3_5/qwen3_5preprocessor.cpp
+++ b/src/cpp/src/module_genai/modules/model/qwen3_5/qwen3_5preprocessor.cpp
@@ -235,14 +235,14 @@ Qwen3_5PreprocessorOutput Qwen3_5Preprocessor::preprocess_video(const ov::Tensor
 
     auto nchw_shape = ov::Shape{batch,
                                 grid_t,
-                                m_preprocess_config.temporal_patch_size,
+                                static_cast<size_t>(m_preprocess_config.temporal_patch_size),
                                 channel,
                                 grid_h / m_preprocess_config.merge_size,
-                                m_preprocess_config.merge_size,
-                                m_preprocess_config.patch_size,
+                                static_cast<size_t>(m_preprocess_config.merge_size),
+                                static_cast<size_t>(m_preprocess_config.patch_size),
                                 grid_w / m_preprocess_config.merge_size,
-                                m_preprocess_config.merge_size,
-                                m_preprocess_config.patch_size};
+                                static_cast<size_t>(m_preprocess_config.merge_size),
+                                static_cast<size_t>(m_preprocess_config.patch_size)};
 
     resized_video = qwen3vl_utils::ovtensor_view(resized_video, nchw_shape);
 

--- a/src/cpp/src/module_genai/modules/model/qwen3_vl/vision_preprocess.cpp
+++ b/src/cpp/src/module_genai/modules/model/qwen3_vl/vision_preprocess.cpp
@@ -78,7 +78,7 @@ ImageSize smart_resize(int num_frames,
         w_bar = static_cast<int>(std::ceil(width * beta / factor)) * factor;
     }
 
-    return {h_bar, w_bar};
+    return {static_cast<size_t>(h_bar), static_cast<size_t>(w_bar)};
 }
 
 ov::Tensor video_padding(const ov::Tensor& video, const size_t& pad) {

--- a/tests/module_genai/cpp/modules/VideoPreprocesModule.cpp
+++ b/tests/module_genai/cpp/modules/VideoPreprocesModule.cpp
@@ -159,16 +159,16 @@ auto test_video_types = std::vector<bool>{true};  // true: single video, false: 
 auto test_devices = std::vector<std::string>{TEST_MODEL::get_device()};
 
 ExpectedOutput qwen3_5_expected_output = {
-    .pixel_values = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
-    .pixel_values_shape = {1056, 3, 2, 16, 16},
-    .video_grid_thw = {3, 16, 22},
-    .video_grid_thw_shape = {1, 3},
-    .pos_embeds = {-0.0263672, -0.320312, 0.0454102, -0.0693359, -0.25, 0.0288086, 0.15332, 0.125977, 0.104004, 0.15625},
-    .pos_embeds_shape = {1056, 768},
-    .rotary_cos = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
-    .rotary_cos_shape = {1056, 64},
-    .rotary_sin = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-    .rotary_sin_shape = {1056, 64}};
+    /*pixel_values=*/{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
+    /*pixel_values_shape=*/{1056, 3, 2, 16, 16},
+    /*video_grid_thw=*/{3, 16, 22},
+    /*video_grid_thw_shape=*/{1, 3},
+    /*pos_embeds=*/{-0.0263672f, -0.320312f, 0.0454102f, -0.0693359f, -0.25f, 0.0288086f, 0.15332f, 0.125977f, 0.104004f, 0.15625f},
+    /*pos_embeds_shape=*/{1056, 768},
+    /*rotary_cos=*/{1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+    /*rotary_cos_shape=*/{1056, 64},
+    /*rotary_sin=*/{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    /*rotary_sin_shape=*/{1056, 64}};
 // <models_type, models_path, expected_output>
 std::vector<std::tuple<std::string, std::string, ExpectedOutput>> test_models = {{"qwen3_5", TEST_MODEL::Qwen3_5_0_8B(), qwen3_5_expected_output}};
 }  // namespace VideoPreprocessModuleTestParams


### PR DESCRIPTION
- processing_qwen3_5.cpp: pass std::vector<float>& instead of float* to resize_bilinear_to_chw()
- qwen3_5preprocessor.cpp: add static_cast<size_t>() for int32_t config values in ov::Shape{} brace-init to fix C2398 narrowing conversion
- qwen3_vl/vision_preprocess.cpp: add static_cast<size_t>() for int return values in ImageSize{} to fix C2397 narrowing conversion
- VideoPreprocesModule.cpp: replace C++20 designated initializers with C++17-compatible positional aggregate initialization (C7555)

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
