### PR TITLE
Xp/update module pipeline api

### DIFF
--- a/samples/cpp/module_genai/md_image_generation.cpp
+++ b/samples/cpp/module_genai/md_image_generation.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <openvino/genai/module_genai/pipeline.hpp>
+#include <openvino/runtime/properties.hpp>
 
 #include <stdexcept>
 
@@ -82,6 +83,7 @@ int main(int argc, char* argv[]) {
         if (argc <= 1) {
             throw std::runtime_error(std::string{"Usage: "} + argv[0] + "\n"
                                      "  -cfg config.yaml \n"
+                                     "  -cache_dir: [Optional] string path, default empty\n"
                                      "  -prompt: input prompt\n"
                                      "  --height: default 512\n"
                                      "  --width: default 512\n"
@@ -91,6 +93,7 @@ int main(int argc, char* argv[]) {
         }
 
         std::filesystem::path config_path = utils::get_input_arg(argc, argv, "-cfg");
+        std::string cache_dir = utils::get_input_arg(argc, argv, "-cache_dir", std::string{});
         std::string prompt = utils::get_input_arg(argc, argv, "-prompt");
         std::string width = utils::get_input_arg(argc, argv, "--width", "512");
         std::string height = utils::get_input_arg(argc, argv, "--height", "512");
@@ -104,7 +107,12 @@ int main(int argc, char* argv[]) {
             std::cout << "[Input] " << key << ": " << value.as<std::string>() << std::endl;
         }
 
-        ov::genai::module::ModulePipeline pipe(config_path);
+        ov::AnyMap properties{};
+        if (!cache_dir.empty()) {
+            properties.insert({ov::cache_dir(cache_dir)});
+        }
+
+        ov::genai::module::ModulePipeline pipe(config_path, properties);
 
         pipe.generate(inputs);
 

--- a/samples/cpp/module_genai/md_omni.cpp
+++ b/samples/cpp/module_genai/md_omni.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <openvino/genai/module_genai/pipeline.hpp>
+#include <openvino/runtime/properties.hpp>
 
 #include <stdexcept>
 
@@ -68,6 +69,7 @@ int main(int argc, char* argv[]) {
             throw std::runtime_error(std::string{"Usage: "} + argv[0] +
                                      "\n"
                                      "  -cfg config.yaml \n"
+                                     "  -cache_dir: [Optional] string path, default empty\n"
                                      "  -prompt: input prompt\n"
                                      "  -img: [Optional] image path\n"
                                      "  -video: [Optional] video path\n"
@@ -75,6 +77,7 @@ int main(int argc, char* argv[]) {
         }
 
         std::filesystem::path config_path = utils::get_input_arg(argc, argv, "-cfg", std::string{});
+        std::string cache_dir = utils::get_input_arg(argc, argv, "-cache_dir", std::string{});
         std::string prompt = utils::get_input_arg(argc, argv, "-prompt", std::string{});
         std::string img_path = utils::get_input_arg(argc, argv, "-img", std::string{});
         std::string video_path = utils::get_input_arg(argc, argv, "-video", std::string{});
@@ -95,7 +98,12 @@ int main(int argc, char* argv[]) {
             std::cout << std::endl;
         }
 
-        ov::genai::module::ModulePipeline pipe(config_path);
+        ov::AnyMap properties{};
+        if (!cache_dir.empty()) {
+            properties.insert({ov::cache_dir(cache_dir)});
+        }
+
+        ov::genai::module::ModulePipeline pipe(config_path, properties);
 
         pipe.generate(inputs);
 

--- a/samples/cpp/module_genai/md_video_generation.cpp
+++ b/samples/cpp/module_genai/md_video_generation.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <openvino/genai/module_genai/pipeline.hpp>
+#include <openvino/runtime/properties.hpp>
 
 #include "utils/utils.hpp"
 #include "yaml-cpp/yaml.h"
@@ -140,6 +141,7 @@ int main(int argc, char* argv[]) {
         if (argc <= 1) {
             throw std::runtime_error(std::string{"Usage: "} + argv[0] + "\n"
                                      "  -cfg <config.yaml>\n"
+                                     "  -cache_dir: [Optional] string path, default empty\n"
                                      "  -prompt <text>\n"
                                      "  --negative_prompt <text>\n"
                                      "  --height <int> (default 480)\n"
@@ -154,6 +156,7 @@ int main(int argc, char* argv[]) {
         }
 
         std::filesystem::path config_path = utils::get_input_arg(argc, argv, "-cfg");
+        std::string cache_dir = utils::get_input_arg(argc, argv, "-cache_dir", std::string{});
         std::string prompt = utils::get_input_arg(argc, argv, "-prompt");
         std::string negative_prompt = utils::get_input_arg(argc, argv, "--negative_prompt", "");
         std::string width = utils::get_input_arg(argc, argv, "--width", "480");
@@ -184,7 +187,12 @@ int main(int argc, char* argv[]) {
             std::cout << "  - " << key << ": " << utils::any_to_string(value) << std::endl;
         }
 
-        ov::genai::module::ModulePipeline pipe(config_path);
+        ov::AnyMap properties{};
+        if (!cache_dir.empty()) {
+            properties.insert({ov::cache_dir(cache_dir)});
+        }
+
+        ov::genai::module::ModulePipeline pipe(config_path, properties);
         pipe.generate(inputs);
 
         auto saved_video_output = pipe.get_output("saved_video");

--- a/samples/cpp/module_genai/md_video_generation.cpp
+++ b/samples/cpp/module_genai/md_video_generation.cpp
@@ -141,7 +141,7 @@ int main(int argc, char* argv[]) {
         if (argc <= 1) {
             throw std::runtime_error(std::string{"Usage: "} + argv[0] + "\n"
                                      "  -cfg <config.yaml>\n"
-                                     "  -cache_dir: [Optional] string path, default empty\n"
+                                     "  -cache_dir <path> [Optional] (default: empty)\n"
                                      "  -prompt <text>\n"
                                      "  --negative_prompt <text>\n"
                                      "  --height <int> (default 480)\n"

--- a/samples/cpp/module_genai/md_visual_language_chat.cpp
+++ b/samples/cpp/module_genai/md_visual_language_chat.cpp
@@ -59,12 +59,16 @@ int main(int argc, char* argv[]) {
             throw std::runtime_error(std::string{"Usage: "} + argv[0] +
                                      "\n"
                                      "  -cfg config.yaml \n"
+                                     "  -enable_cache_dir: [Optional] true/false, default false\n"
                                      "  -prompt: input prompt\n"
                                      "  -img: [Optional] image path\n"
                                      "  -video: [Optional] video path\n");
         }
 
         std::filesystem::path config_path = utils::get_input_arg(argc, argv, "-cfg", std::string{});
+        std::string enable_cache_dir_str = utils::get_input_arg(argc, argv, "-enable_cache_dir", std::string{"false"});
+        bool enable_cache_dir = (enable_cache_dir_str == "1" || enable_cache_dir_str == "true" ||
+                                 enable_cache_dir_str == "True" || enable_cache_dir_str == "TRUE");
         std::string prompt = utils::get_input_arg(argc, argv, "-prompt", std::string{});
         std::string img_path = utils::get_input_arg(argc, argv, "-img", std::string{});
         std::string video_path = utils::get_input_arg(argc, argv, "-video", std::string{});
@@ -75,7 +79,12 @@ int main(int argc, char* argv[]) {
             std::cout << "[Input] " << key << ": " << value.as<std::string>() << std::endl;
         }
 
-        ov::genai::module::ModulePipeline pipe(config_path);
+        ov::AnyMap properties{};
+        if (enable_cache_dir) {
+            properties.insert({ov::cache_dir("vlm_cache")});
+        }
+
+        ov::genai::module::ModulePipeline pipe(config_path, properties);
 
         pipe.generate(inputs);
 

--- a/samples/cpp/module_genai/md_visual_language_chat.cpp
+++ b/samples/cpp/module_genai/md_visual_language_chat.cpp
@@ -59,16 +59,14 @@ int main(int argc, char* argv[]) {
             throw std::runtime_error(std::string{"Usage: "} + argv[0] +
                                      "\n"
                                      "  -cfg config.yaml \n"
-                                     "  -enable_cache_dir: [Optional] true/false, default false\n"
+                                     "  -cache_dir: [Optional] string path, default empty\n"
                                      "  -prompt: input prompt\n"
                                      "  -img: [Optional] image path\n"
                                      "  -video: [Optional] video path\n");
         }
 
         std::filesystem::path config_path = utils::get_input_arg(argc, argv, "-cfg", std::string{});
-        std::string enable_cache_dir_str = utils::get_input_arg(argc, argv, "-enable_cache_dir", std::string{"false"});
-        bool enable_cache_dir = (enable_cache_dir_str == "1" || enable_cache_dir_str == "true" ||
-                                 enable_cache_dir_str == "True" || enable_cache_dir_str == "TRUE");
+        std::string cache_dir = utils::get_input_arg(argc, argv, "-cache_dir", std::string{});
         std::string prompt = utils::get_input_arg(argc, argv, "-prompt", std::string{});
         std::string img_path = utils::get_input_arg(argc, argv, "-img", std::string{});
         std::string video_path = utils::get_input_arg(argc, argv, "-video", std::string{});
@@ -80,8 +78,8 @@ int main(int argc, char* argv[]) {
         }
 
         ov::AnyMap properties{};
-        if (enable_cache_dir) {
-            properties.insert({ov::cache_dir("vlm_cache")});
+        if (!cache_dir.empty()) {
+            properties.insert({ov::cache_dir(cache_dir)});
         }
 
         ov::genai::module::ModulePipeline pipe(config_path, properties);

--- a/src/cpp/include/openvino/genai/module_genai/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/module_genai/pipeline.hpp
@@ -17,7 +17,7 @@ class OPENVINO_GENAI_EXPORTS ModulePipeline {
 
 public:
     /// @brief Construct a ModulePipeline.
-    /// @param config_yaml_content YAML content string for the pipeline configuration.
+    /// @param config_yaml_path Path to the YAML configuration file.
     /// @param properties A config to pass to ov::Core::compile_model().
     /// @param models_map optional pre-loaded models map. Format: {"module_name": {"model_name": ov.Model, ...}, ...}.
     /// This is used to pass pre-loaded models to the pipeline, so that the pipeline can skip loading and compiling

--- a/src/cpp/include/openvino/genai/module_genai/pipeline.hpp
+++ b/src/cpp/include/openvino/genai/module_genai/pipeline.hpp
@@ -3,14 +3,6 @@
 
 #pragma once
 
-#include <filesystem>
-#include <fstream>
-#include <optional>
-#include <string>
-#include <vector>
-#include <map>
-
-#include "openvino/genai/generation_config.hpp"
 #include "openvino/genai/llm_pipeline.hpp"
 
 namespace ov {
@@ -24,11 +16,25 @@ using ConfigModelsMap = std::map<std::string, std::map<std::string, std::shared_
 class OPENVINO_GENAI_EXPORTS ModulePipeline {
 
 public:
-    // config_yaml_path: yaml file.
-    ModulePipeline(const std::filesystem::path& config_yaml_path, ConfigModelsMap models_map = {});
+    /// @brief Construct a ModulePipeline.
+    /// @param config_yaml_content YAML content string for the pipeline configuration.
+    /// @param properties A config to pass to ov::Core::compile_model().
+    /// @param models_map optional pre-loaded models map. Format: {"module_name": {"model_name": ov.Model, ...}, ...}.
+    /// This is used to pass pre-loaded models to the pipeline, so that the pipeline can skip loading and compiling
+    /// these models
+    ModulePipeline(const std::filesystem::path& config_yaml_path,
+                   const ov::AnyMap& properties = {},
+                   ConfigModelsMap models_map = {});
 
-    // config_yaml_content: yaml content string.
-    ModulePipeline(const std::string& config_yaml_content, ConfigModelsMap models_map = {});
+    /// @brief Construct a ModulePipeline.
+    /// @param config_yaml_content YAML content string for the pipeline configuration.
+    /// @param properties A config to pass to ov::Core::compile_model().
+    /// @param models_map optional pre-loaded models map. Format: {"module_name": {"model_name": ov.Model, ...}, ...}.
+    /// This is used to pass pre-loaded models to the pipeline, so that the pipeline can skip loading and compiling
+    /// these models
+    ModulePipeline(const std::string& config_yaml_content,
+                   const ov::AnyMap& properties = {},
+                   ConfigModelsMap models_map = {});
 
     ~ModulePipeline();
 

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa.cpp
@@ -81,6 +81,7 @@ pipeline_modules:
         type: "String"
     params:
       model_path: "model_path"              # Directory containing config.json + IR files
+      cache_dir: "cache_dir"                # Optional directory for caching compiled models, e.g. for GPU device, recommended to set this to a local disk path for better performance
       model_cfg_path: "model_config.json"   # Optional fallback when model_path is not provided
       max_new_tokens: "256"
       text_device: ""                       # Override device for text model (e.g. CPU for VL TDR avoidance)
@@ -202,6 +203,7 @@ bool LLMInferenceSDPAModule::initialize() {
         }
     }
     
+    check_cache_dir();
 
     // Override max_new_tokens from params
     {
@@ -271,14 +273,18 @@ bool LLMInferenceSDPAModule::initialize() {
             text_device = it->second;
     }
 
-    const ov::AnyMap latency_props = {
+    ov::AnyMap properties = {
         ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY),
         ov::hint::num_requests(1)
     };
 
+    if (!m_cache_dir.empty()) {
+        properties.insert({ov::cache_dir.name(), m_cache_dir});
+    }
+
     m_device = text_device;
     GENAI_INFO("LLMInferenceSDPAModule: compiling text -> " + text_device);
-    m_compiled_text = m_core.compile_model(text_ir, text_device, latency_props);
+    m_compiled_text = m_core.compile_model(text_ir, text_device, properties);
 
     // Build tokenizer
     try {

--- a/src/cpp/src/module_genai/pipeline.cpp
+++ b/src/cpp/src/module_genai/pipeline.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <sstream>
 #include "logger.hpp"
+#include "openvino/runtime/properties.hpp"
 
 #include "openvino/genai/module_genai/pipeline.hpp"
 
@@ -19,19 +20,54 @@ namespace genai {
 
 namespace module {
 
+namespace {
+
+void apply_properties_to_pipeline_desc(const PipelineDesc::PTR& pipeline_desc, const ov::AnyMap& properties) {
+    const auto it = properties.find(ov::cache_dir.name());
+    if (it == properties.end()) {
+        return;
+    }
+
+    OPENVINO_ASSERT(it->second.is<std::string>(), "ModulePipeline: '", ov::cache_dir.name(), "' must be string");
+    const std::string cache_dir = it->second.as<std::string>();
+
+    auto set_cache_dir = [&cache_dir](PipelineModulesDesc& modules_desc) {
+        for (auto& [module_name, module_desc] : modules_desc) {
+            (void)module_name;
+            if (module_desc && module_desc->params.find("cache_dir") == module_desc->params.end()) {
+                module_desc->params["cache_dir"] = cache_dir;
+            }
+        }
+    };
+
+    set_cache_dir(pipeline_desc->main_pipeline_desc);
+    for (auto& [sub_pipeline_name, sub_modules] : pipeline_desc->sub_pipeline_descs) {
+        (void)sub_pipeline_name;
+        set_cache_dir(sub_modules);
+    }
+}
+
+}  // namespace
+
 // config_yaml_path: yaml file.
-ModulePipeline::ModulePipeline(const std::filesystem::path& config_yaml_path, ConfigModelsMap models_map) {
+ModulePipeline::ModulePipeline(const std::filesystem::path& config_yaml_path,
+                               const ov::AnyMap& properties,
+                               ConfigModelsMap models_map) {
     auto pipeline_desc = utils::load_config(config_yaml_path.string());
     pipeline_desc->setConfigModelsMap(models_map);
+    apply_properties_to_pipeline_desc(pipeline_desc, properties);
 
     ModulePipelineImpl* pImpl = new ModulePipelineImpl(pipeline_desc->main_pipeline_desc, pipeline_desc);
     OPENVINO_ASSERT(pImpl != NULL, "Create ModulePipelineImpl return null.");
     m_pipeline_impl = (ModulePipelineImpl*)pImpl;
 }
 
-ModulePipeline::ModulePipeline(const std::string& config_yaml_content, ConfigModelsMap models_map) {
+ModulePipeline::ModulePipeline(const std::string& config_yaml_content,
+                               const ov::AnyMap& properties,
+                               ConfigModelsMap models_map) {
     auto pipeline_desc = utils::load_config_from_string(config_yaml_content);
     pipeline_desc->setConfigModelsMap(models_map);
+    apply_properties_to_pipeline_desc(pipeline_desc, properties);
 
     ModulePipelineImpl* pImpl = new ModulePipelineImpl(pipeline_desc->main_pipeline_desc, pipeline_desc);
     OPENVINO_ASSERT(pImpl != NULL, "Create ModulePipelineImpl return null.");

--- a/src/python/py_module_pipeline.cpp
+++ b/src/python/py_module_pipeline.cpp
@@ -218,7 +218,7 @@ void init_module_pipeline(py::module_& m) {
                  if (!config.is_none()) {
                      PyErr_WarnEx(
                          PyExc_DeprecationWarning,
-                         "'config' parameters is deprecated, please use kwargs to pass config properties instead.",
+                         "'config' parameter is deprecated, please use kwargs to pass config properties instead.",
                          1);
                      auto config_map = config.cast<std::map<std::string, py::object>>();
                      auto config_properties = pyutils::properties_to_any_map(config_map);

--- a/src/python/py_module_pipeline.cpp
+++ b/src/python/py_module_pipeline.cpp
@@ -209,12 +209,27 @@ void init_module_pipeline(py::module_& m) {
                                                   "ModulePipeline",
                                                   "This class is used for generation with ModulePipeline")
         .def(py::init([py_dict_to_config_models_map](const std::filesystem::path& config_yaml_path,
-                                                      const py::object& models_map,
-                                                      const py::kwargs& kwargs) {
+                                                     const py::object& config,
+                                                     const py::object& models_map,
+                                                     const py::kwargs& kwargs) {
                  auto cpp_models_map = py_dict_to_config_models_map(models_map);
-                 return std::make_unique<ov::genai::module::ModulePipeline>(config_yaml_path, cpp_models_map);
+
+                 ov::AnyMap properties = pyutils::kwargs_to_any_map(kwargs);
+                 if (!config.is_none()) {
+                     PyErr_WarnEx(
+                         PyExc_DeprecationWarning,
+                         "'config' parameters is deprecated, please use kwargs to pass config properties instead.",
+                         1);
+                     auto config_map = config.cast<std::map<std::string, py::object>>();
+                     auto config_properties = pyutils::properties_to_any_map(config_map);
+                     properties.insert(config_properties.begin(), config_properties.end());
+                 }
+                 return std::make_unique<ov::genai::module::ModulePipeline>(config_yaml_path,
+                                                                            properties,
+                                                                            cpp_models_map);
              }),
              py::arg("config_yaml_path"),
+             py::arg("config") = py::none(),
              py::arg("models_map") = py::none(),
              R"(
             Module Pipeline class constructor.
@@ -225,12 +240,26 @@ void init_module_pipeline(py::module_& m) {
             :type models_map: dict[str, dict[str, openvino.Model]], optional
         )")
         .def(py::init([py_dict_to_config_models_map](const std::string& config_yaml_content,
-                                                      const py::object& models_map,
-                                                      const py::kwargs& kwargs) {
+                                                     const py::object& config,
+                                                     const py::object& models_map,
+                                                     const py::kwargs& kwargs) {
                  auto cpp_models_map = py_dict_to_config_models_map(models_map);
-                 return std::make_unique<ov::genai::module::ModulePipeline>(config_yaml_content, cpp_models_map);
+
+                 ov::AnyMap properties = pyutils::kwargs_to_any_map(kwargs);
+                 if (!config.is_none()) {
+                     PyErr_WarnEx(
+                         PyExc_DeprecationWarning,
+                         "'config' parameters is deprecated, please use kwargs to pass config properties instead.",
+                         1);
+                     auto config_map = config.cast<std::map<std::string, py::object>>();
+                     auto config_properties = pyutils::properties_to_any_map(config_map);
+                     properties.insert(config_properties.begin(), config_properties.end());
+                 }
+
+                 return std::make_unique<ov::genai::module::ModulePipeline>(config_yaml_content, properties, cpp_models_map);
              }),
              py::arg("config_yaml_content"),
+             py::arg("config") = py::none(),
              py::arg("models_map") = py::none(),
              R"(
             Module Pipeline class constructor.
@@ -260,8 +289,8 @@ void init_module_pipeline(py::module_& m) {
                     pipe.generate_async(ov_inputs);
                 }
             },
-            (std::string("generate_async(**kwargs) -> None\n\n") + "Accepts arbitrary keyword arguments as AnyMap.\n\n" +
-             module_generate_docstring)
+            (std::string("generate_async(**kwargs) -> None\n\n") +
+             "Accepts arbitrary keyword arguments as AnyMap.\n\n" + module_generate_docstring)
                 .c_str())
         .def(
             "get_output",

--- a/src/python/py_module_pipeline.cpp
+++ b/src/python/py_module_pipeline.cpp
@@ -249,7 +249,7 @@ void init_module_pipeline(py::module_& m) {
                  if (!config.is_none()) {
                      PyErr_WarnEx(
                          PyExc_DeprecationWarning,
-                         "'config' parameters is deprecated, please use kwargs to pass config properties instead.",
+                         "'config' parameter is deprecated, please use kwargs to pass config properties instead.",
                          1);
                      auto config_map = config.cast<std::map<std::string, py::object>>();
                      auto config_properties = pyutils::properties_to_any_map(config_map);

--- a/tests/module_genai/cpp/utils/ut_modules_base.hpp
+++ b/tests/module_genai/cpp/utils/ut_modules_base.hpp
@@ -39,7 +39,7 @@ public:
             std::cout << "Saved YAML content to " << filename << std::endl;
         }
 
-        ov::genai::module::ModulePipeline pipe(yaml_content, m_models_map);
+        ov::genai::module::ModulePipeline pipe(yaml_content, ov::AnyMap{}, m_models_map);
 
         ov::AnyMap inputs = prepare_inputs();
         if (m_async) {


### PR DESCRIPTION
This pull request adds support for passing an optional `cache_dir` property to the `ModulePipeline` in the OpenVINO GenAI module pipeline C++ and Python APIs. This allows users to specify a cache directory for compiled models, which can improve performance, especially on GPU devices. The change is reflected across the C++ API, Python bindings, sample applications, and internal module handling. The most important changes are summarized below:

**API and Interface Enhancements:**

* The `ModulePipeline` constructors in both C++ (`pipeline.hpp`) and Python bindings now accept an optional `properties` (`ov::AnyMap`) argument, allowing users to pass configuration options such as `cache_dir`. The old `config` parameter in Python is now deprecated in favor of keyword arguments. [[1]](diffhunk://#diff-5e21217e2286775e73e5a4f5a5caea884b38152f37976c256e9af58ed4965bc7L27-R37) [[2]](diffhunk://#diff-12f3ad8de77e74485f308d42df717235c796de464e4b0d91d9e04d93265db140R212-R232) [[3]](diffhunk://#diff-12f3ad8de77e74485f308d42df717235c796de464e4b0d91d9e04d93265db140R243-R262)

**Sample Application Updates:**

* All C++ sample applications (`md_image_generation.cpp`, `md_omni.cpp`, `md_video_generation.cpp`, `md_visual_language_chat.cpp`) are updated to accept a `-cache_dir` command-line argument, which is passed to the pipeline if provided. [[1]](diffhunk://#diff-75211165af67cd139da8f29a33b056fcf27a5191c19571599545e086905e08adR86) [[2]](diffhunk://#diff-75211165af67cd139da8f29a33b056fcf27a5191c19571599545e086905e08adR96) [[3]](diffhunk://#diff-75211165af67cd139da8f29a33b056fcf27a5191c19571599545e086905e08adL107-R115) [[4]](diffhunk://#diff-13c4d8bbe351e5bd2ff3949e968ad77d91df8e2912877322cee9b02a661f8114R72-R80) [[5]](diffhunk://#diff-13c4d8bbe351e5bd2ff3949e968ad77d91df8e2912877322cee9b02a661f8114L98-R106) [[6]](diffhunk://#diff-2f41674a0ceeb97036e764b7c22ed42b315cc6859f9916a2f635e407affc832cR144) [[7]](diffhunk://#diff-2f41674a0ceeb97036e764b7c22ed42b315cc6859f9916a2f635e407affc832cR159) [[8]](diffhunk://#diff-2f41674a0ceeb97036e764b7c22ed42b315cc6859f9916a2f635e407affc832cL187-R195) [[9]](diffhunk://#diff-9849b47bb5be83b361e60f3449efcec5182a9bbb950a017e141cdf2c0f118ae6R62-R69) [[10]](diffhunk://#diff-9849b47bb5be83b361e60f3449efcec5182a9bbb950a017e141cdf2c0f118ae6L78-R85)

**Pipeline Implementation and Internal Handling:**

* The pipeline implementation applies the `cache_dir` property to all modules in the pipeline and sub-pipelines, ensuring that the cache directory is consistently set if provided.

**Module-Level Support for Caching:**

* The LLM inference SDPA module (`md_llm_inference_sdpa.cpp`) now supports a `cache_dir` parameter, and passes it to the model compilation step if specified. This is documented and handled in module initialization. [[1]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR84) [[2]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR206) [[3]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaL274-R287)

**Testing and Utilities:**

* Unit test utilities are updated to use the new `ModulePipeline` constructor signature with the `properties` parameter.

These changes improve flexibility and performance for users running GenAI pipelines, especially in environments where model compilation caching is beneficial.