### PR TITLE
add profiling

### DIFF
--- a/src/cpp/src/module_genai/modules/autoencoder_kl_wan.cpp
+++ b/src/cpp/src/module_genai/modules/autoencoder_kl_wan.cpp
@@ -157,7 +157,10 @@ void AutoencoderKLWan::warmup(size_t num_frames) {
 
     // Run inference to trigger JIT compilation
     m_decoder_request.set_input_tensor(dummy);
-    m_decoder_request.infer();
+    {
+        PROFILE(pm, "AutoencoderKLWan::Warmup infer");
+        m_decoder_request.infer();
+    }
 
     auto warmup_end = std::chrono::high_resolution_clock::now();
     double warmup_time_ms = std::chrono::duration<double, std::milli>(warmup_end - warmup_start).count();
@@ -245,7 +248,7 @@ ov::Tensor AutoencoderKLWan::decode(ov::Tensor latents) {
 ov::Tensor AutoencoderKLWan::decode_single(ov::Tensor latents) {
     m_decoder_request.set_input_tensor(latents);
     {
-        PROFILE(pm, "vae_decoder infer");
+        PROFILE(pm, "AutoencoderKLWan::decode_single infer");
         m_decoder_request.infer();
     }
     ov::Tensor output = m_decoder_request.get_output_tensor();

--- a/src/cpp/src/module_genai/modules/md_denoiser_loop/class.cpp
+++ b/src/cpp/src/module_genai/modules/md_denoiser_loop/class.cpp
@@ -287,16 +287,17 @@ ov::Tensor DenoiserLoopModule::run(
         }
 
         if (m_splitted_model) {
-            PROFILE(pm, "splitted_model_infer");
             ov::AnyMap splitted_model_inputs = {{"hidden_states", input_hidden_states},
                                                 {"timestep", input_timestep},
                                                 {"encoder_hidden_states", input_encoder_hidden_states}};
+            PROFILE(pm, "DenoiserLoopModule::run m_splitted_model_infer infer");
             m_splitted_model_infer->infer(splitted_model_inputs);
         } else {
             m_request.set_tensor("hidden_states", input_hidden_states);
             m_request.set_tensor("timestep", input_timestep);
             m_request.set_tensor("encoder_hidden_states", input_encoder_hidden_states);
-            PROFILE(pm, "infer");
+
+            PROFILE(pm, "DenoiserLoopModule::run infer");
             m_request.infer();
         }
 
@@ -367,27 +368,31 @@ ov::Tensor DenoiserLoopModule::run(
         }
 
         if (m_splitted_model) {
-            PROFILE(pm, "splitted_model_infer");
             ov::AnyMap splitted_model_inputs = {{"hidden_states", latents},
                                                 {"timestep", timestep},
                                                 {"encoder_hidden_states", prompt_tensor}};
             m_splitted_model_infer->set_output_tensor(0, noise_pred);
+
+            PROFILE(pm, "DenoiserLoopModule::run m_splitted_model_infer infer");
             m_splitted_model_infer->infer(splitted_model_inputs);
         } else {
             m_request.set_tensor("hidden_states", latents);
             m_request.set_tensor("timestep", timestep);
             m_request.set_tensor("encoder_hidden_states", prompt_tensor);
             m_request.set_output_tensor(0, noise_pred);
+
+            PROFILE(pm, "DenoiserLoopModule::run m_request infer");
             m_request.infer();
         }
 
         if (guidance_scale > 1.0f && negative_prompt_tensor.has_value()) {
             if (m_splitted_model) {
-                PROFILE(pm, "splitted_model_infer_uncond");
                 ov::AnyMap splitted_model_inputs = {{"hidden_states", latents},
                                                     {"timestep", timestep},
                                                     {"encoder_hidden_states", negative_prompt_tensor.value()}};
                 m_splitted_model_infer->set_output_tensor(0, noise_uncond);
+
+                PROFILE(pm, "DenoiserLoopModule::run m_splitted_model_infer infer");
                 m_splitted_model_infer->infer(splitted_model_inputs);
             }
             else {
@@ -395,6 +400,8 @@ ov::Tensor DenoiserLoopModule::run(
                 m_request.set_tensor("timestep", timestep);
                 m_request.set_tensor("encoder_hidden_states", negative_prompt_tensor.value());
                 m_request.set_output_tensor(0, noise_uncond);
+
+                PROFILE(pm, "DenoiserLoopModule::run m_request infer_uncond");
                 m_request.infer();
             }
 

--- a/src/cpp/src/module_genai/modules/md_denoiser_loop/splitted_model_infer.cpp
+++ b/src/cpp/src/module_genai/modules/md_denoiser_loop/splitted_model_infer.cpp
@@ -156,7 +156,10 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
         m_full_infer_request.set_tensor(input.first, input.second.as<ov::Tensor>());
     }
 
-    m_full_infer_request.infer();
+    {
+        PROFILE(pm, "CSplittedModelInfer::infer m_full_infer_request");
+        m_full_infer_request.infer();
+    }
 #else
     int num_splitted_models = static_cast<int>(m_compiled_models.size());
     OPENVINO_ASSERT(num_splitted_models > 1,
@@ -180,7 +183,11 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
     for (const auto& input : inputs) {
         m_preprocess_infer_request.set_tensor(input.first, input.second.as<ov::Tensor>());
     }
-    m_preprocess_infer_request.infer();
+
+    {
+        PROFILE(pm, "CSplittedModelInfer::infer m_preprocess_infer_request");
+        m_preprocess_infer_request.infer();
+    }
 
     // The "tokens" tensor produced by the preprocess stage is used as the initial hidden_states.
     ov::Tensor hidden_states_tensor = m_preprocess_infer_request.get_tensor("tokens");
@@ -233,7 +240,7 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
         curInferRequest.set_tensor("rotary_cos", rotary_cos_tensor);
         curInferRequest.set_tensor("rotary_sin", rotary_sin_tensor);
         {
-            PROFILE(pmi, "infer");
+            PROFILE(pmi, "CSplittedModelInfer::infer curInferRequest");
             curInferRequest.infer();
         }
 
@@ -268,7 +275,10 @@ void CSplittedModelInfer::infer(const ov::AnyMap& inputs) {
     m_postprocess_infer_request.set_tensor("ppf", ppf_tensor);
     m_postprocess_infer_request.set_tensor("pph", pph_tensor);
     m_postprocess_infer_request.set_tensor("ppw", ppw_tensor);
-    m_postprocess_infer_request.infer();
+    {
+        PROFILE(pm, "CSplittedModelInfer::infer m_postprocess_infer_request");
+        m_postprocess_infer_request.infer();
+    }
 #endif
 }
 

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa.cpp
@@ -27,6 +27,7 @@
 #include "module_genai/utils/com_utils.hpp"
 #include "modeling/models/qwen3_vl/processing_qwen3_vl.hpp"
 #include "modeling/models/qwen3_omni/processing_qwen3_omni.hpp"
+#include "module_genai/utils/profiler.hpp"
 
 namespace ov {
 namespace genai {
@@ -357,7 +358,10 @@ std::string LLMInferenceSDPAModule::run_text_decode(const ov::Tensor& input_ids,
     }
 
     const auto t_prefill0 = std::chrono::steady_clock::now();
-    text_req.infer();
+    {
+        PROFILE(pm, "LLMInferenceSDPAModule::run_text_decode prefill infer");
+        text_req.infer();
+    }
     const auto t_prefill1 = std::chrono::steady_clock::now();
     int64_t next_id = argmax_last(text_req.get_tensor(TIO::kLogits));
 
@@ -396,7 +400,11 @@ std::string LLMInferenceSDPAModule::run_text_decode(const ov::Tensor& input_ids,
             text_req.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
         }
 
-        text_req.infer();
+        {
+            PROFILE(pm, "LLMInferenceSDPAModule::run_text_decode step infer");
+            text_req.infer();
+        }
+
         next_id = argmax_last(text_req.get_tensor(TIO::kLogits));
         generated.push_back(next_id);
         ++decode_steps;
@@ -481,7 +489,10 @@ std::string LLMInferenceSDPAModule::run_vl_decode(const ov::Tensor& input_ids,
     }
 
     const auto t_prefill0 = std::chrono::steady_clock::now();
-    text_req.infer();
+    {
+        PROFILE(pm, "LLMInferenceSDPAModule::run_vl_decode prefill infer");
+        text_req.infer();
+    }
     const auto t_prefill1 = std::chrono::steady_clock::now();
     int64_t next_id = argmax_last(text_req.get_tensor(TIO::kLogits));
 
@@ -540,7 +551,10 @@ std::string LLMInferenceSDPAModule::run_vl_decode(const ov::Tensor& input_ids,
         text_req.set_tensor(TIO::kVisualEmbeds,  dec_vis);
         text_req.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
 
-        text_req.infer();
+        {
+            PROFILE(pm, "LLMInferenceSDPAModule::run_vl_decode step infer");
+            text_req.infer();
+        }
         next_id = argmax_last(text_req.get_tensor(TIO::kLogits));
         generated.push_back(next_id);
         ++decode_steps;
@@ -629,7 +643,10 @@ std::string LLMInferenceSDPAModule::run_vl_decode(const ov::Tensor& input_ids,
     }
 
     const auto t_prefill0 = std::chrono::steady_clock::now();
-    text_req.infer();
+    {
+        PROFILE(pm, "LLMInferenceSDPAModule::run_text_decode prefill infer");
+        text_req.infer();
+    }
     const auto t_prefill1 = std::chrono::steady_clock::now();
     int64_t next_id = argmax_last(text_req.get_tensor(TIO::kLogits));
 
@@ -682,7 +699,11 @@ std::string LLMInferenceSDPAModule::run_vl_decode(const ov::Tensor& input_ids,
             text_req.set_tensor(name, decode_deepstack[i]);
         }
 
-        text_req.infer();
+        {
+            PROFILE(pm, "LLMInferenceSDPAModule::run_qwen3_omni_decode step infer");
+            text_req.infer();
+        }
+
         next_id = argmax_last(text_req.get_tensor(TIO::kLogits));
         generated.push_back(next_id);
         ++decode_steps;

--- a/src/cpp/src/module_genai/modules/md_vision_encoder.cpp
+++ b/src/cpp/src/module_genai/modules/md_vision_encoder.cpp
@@ -23,6 +23,7 @@
 #include "visual_language/vision_encoder.hpp"
 #include "visual_language/vl_sdpa_transformations.hpp"
 #include "models/qwen3_omni/qwen3_omni_config.hpp"
+#include "module_genai/utils/profiler.hpp"
 
 
 namespace ov {
@@ -377,7 +378,11 @@ std::pair<ov::Tensor, ov::Tensor> VisionEncoderModule::embed(const EncodedImage 
     }
     vision_embeddings_merger.set_tensor("rotary_pos_emb", rotary_pos_emb);
     vision_embeddings_merger.set_tensor("window_index", window_index);
-    vision_embeddings_merger.infer();
+    {
+        PROFILE(pm, "VisionEncoderModule::embed vision_embeddings_merger infer");
+        vision_embeddings_merger.infer();
+    }
+
     ov::Tensor processed_vision_embeds = vision_embeddings_merger.get_output_tensor();
 
     auto out_vision_shape = processed_vision_embeds.get_shape();
@@ -440,8 +445,12 @@ Qwen3_5VisionEmbeddingResult VisionEncoderModule::embed(
     if (model_type == VLMModelType::QWEN3_OMNI) {
         vision_embed_request.set_tensor("attention_mask", build_vision_attention_mask(grid_thw));
     }
-    
-    vision_embed_request.infer();
+
+    {
+        PROFILE(pm, "VisionEncoderModule::embed vision_embed_request infer");
+        vision_embed_request.infer();
+    }
+
     ov::Tensor vision_embeds = vision_embed_request.get_tensor("visual_embeds");
 
     const auto &ids_shape = input_ids.get_shape();
@@ -651,7 +660,11 @@ Qwen3OmniVisionEmbeddingResult VisionEncoderModule::embed(
         vision_embed_request.set_tensor("rotary_sin", vision_input.value().rotary_sin);
         vision_embed_request.set_tensor("attention_mask", build_vision_attention_mask(vision_input.value().grid_thw));
 
-        vision_embed_request.infer();
+        {
+            PROFILE(pm, "VisionEncoderModule::embed vision_embed_request infer");
+            vision_embed_request.infer();
+        }
+
         vision_embeds = vision_embed_request.get_tensor("visual_embeds");
         grid_thw = vision_input.value().grid_thw;
 

--- a/src/cpp/src/module_genai/modules/unipc_multistep_scheduler.cpp
+++ b/src/cpp/src/module_genai/modules/unipc_multistep_scheduler.cpp
@@ -24,6 +24,7 @@
 #include "openvino/op/strided_slice.hpp"
 #include "utils.hpp"
 #include "module_genai/utils/tensor_utils.hpp"
+#include "module_genai/utils/profiler.hpp"
 
 
 namespace ov::genai::module {
@@ -1085,7 +1086,10 @@ ov::Tensor UniPCMultistepScheduler::multistep_uni_c_bh_update(
     } else {
         m_c_solver.set_input_tensor(0, R);
         m_c_solver.set_input_tensor(1, b);
-        m_c_solver.infer();
+        {
+            PROFILE(pm, "UniPCMultistepScheduler::multistep_uni_p_bh_update m_c_solver infer");
+            m_c_solver.infer();
+        }
         rhos_c = m_c_solver.get_output_tensor(0);
     }
 
@@ -1226,7 +1230,10 @@ ov::Tensor UniPCMultistepScheduler::multistep_uni_p_bh_update(
         } else {
             m_p_solver.set_input_tensor(0, R);
             m_p_solver.set_input_tensor(1, b);
-            m_p_solver.infer();
+            {
+                PROFILE(pm, "UniPCMultistepScheduler::multistep_uni_p_bh_update m_p_solver infer");
+                m_p_solver.infer();
+            }
             rhos_p = m_p_solver.get_output_tensor(0);
         }
     }


### PR DESCRIPTION
This pull request adds detailed profiling to various inference steps across multiple modules in the codebase. The main goal is to improve profiling granularity and clarity, making it easier to identify performance bottlenecks and understand the execution flow during model inference. Profiling macros are now placed around key inference calls, with descriptive labels indicating the module and function context.

**Profiling Enhancements:**

* Added `PROFILE` macros with descriptive names around all major inference calls in the following modules:
  - `AutoencoderKLWan` (in both `warmup` and `decode_single` methods) [[1]](diffhunk://#diff-c97955a89a525fc5290b08d7b4b376c2f1c622a32470bd8e8ae2643ddd6581c1R160-R163) [[2]](diffhunk://#diff-c97955a89a525fc5290b08d7b4b376c2f1c622a32470bd8e8ae2643ddd6581c1L248-R251)
  - `DenoiserLoopModule` (in both conditional branches of `run`, including unconditional guidance) [[1]](diffhunk://#diff-e02a1b76cea0c8a45be481de112d2009a9a5cac3dfa7a05051f7c545ab8c383eL290-R300) [[2]](diffhunk://#diff-e02a1b76cea0c8a45be481de112d2009a9a5cac3dfa7a05051f7c545ab8c383eL370-R404)
  - `CSplittedModelInfer` (in all stages: full, preprocess, per-layer, and postprocess inference) [[1]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67R159-R162) [[2]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67R186-R190) [[3]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67L236-R243) [[4]](diffhunk://#diff-29044241ee9efadbcfac73d518e189be6496125642ae2cff7bb38635512a8a67R278-R281)
  - `LLMInferenceSDPAModule` (for both text and vision-language decoding, including prefill and step inferences) [[1]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR361-R364) [[2]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR403-R407) [[3]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR492-R495) [[4]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR554-R557) [[5]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR646-R649) [[6]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR702-R706)
  - `VisionEncoderModule` (in all embedding methods) [[1]](diffhunk://#diff-49896219feac2556a46a6cddcc5b01fe221710b64f917b73a51b4d56d240eba8R381-R385) [[2]](diffhunk://#diff-49896219feac2556a46a6cddcc5b01fe221710b64f917b73a51b4d56d240eba8R449-R453) [[3]](diffhunk://#diff-49896219feac2556a46a6cddcc5b01fe221710b64f917b73a51b4d56d240eba8R663-R667)
  - `UniPCMultistepScheduler` (in both `multistep_uni_c_bh_update` and `multistep_uni_p_bh_update`) [[1]](diffhunk://#diff-95983d59355db8278c0754b880d8df9d195de10d9a26f08ca9371757ca2d8937R1089-R1092) [[2]](diffhunk://#diff-95983d59355db8278c0754b880d8df9d195de10d9a26f08ca9371757ca2d8937R1233-R1236)

**Supporting Changes:**

* Added missing includes for `profiler.hpp` where necessary to support the new profiling calls. [[1]](diffhunk://#diff-1723ed206c5193f911dace74190b3b1711ea97135c0d3ffa3cb91d5a042d20aaR30) [[2]](diffhunk://#diff-49896219feac2556a46a6cddcc5b01fe221710b64f917b73a51b4d56d240eba8R26) [[3]](diffhunk://#diff-95983d59355db8278c0754b880d8df9d195de10d9a26f08ca9371757ca2d8937R27)

These changes provide more precise and contextual performance measurements, which will help with debugging and optimization efforts.