### PR TITLE
Remove m_compiled_text and retain m_infer_request

### DIFF
--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/md_llm_inference_sdpa.hpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/md_llm_inference_sdpa.hpp
@@ -65,8 +65,9 @@ protected:
 protected:    
     bool initialize(const VLMModelType& model_type);
 
-    // Compiled text model + infer request
-    std::optional<ov::CompiledModel> m_compiled_text;
+    // LLM infer request.
+    ov::InferRequest m_infer_request;
+
     bool m_text_uses_vl_ir = false;
 
     // Stop token tracking

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_5.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_5.cpp
@@ -105,7 +105,8 @@ LLMInferenceSDPAImpl_Qwen3_5::LLMInferenceSDPAImpl_Qwen3_5(const IBaseModuleDesc
         properties.insert({ov::cache_dir.name(), m_cache_dir});
     }
 
-    m_compiled_text = ov::genai::utils::singleton_core().compile_model(llm_model, m_device, properties);
+    auto compiled_model = ov::genai::utils::singleton_core().compile_model(llm_model, m_device, properties);
+    m_infer_request = compiled_model.create_infer_request();
 }
 
 void LLMInferenceSDPAImpl_Qwen3_5::run() {
@@ -145,32 +146,32 @@ std::string LLMInferenceSDPAImpl_Qwen3_5::run_text_decode(const ov::Tensor& inpu
     const int64_t prompt_len = static_cast<int64_t>(input_ids.get_shape()[1]);
 
     auto beam_idx = LLMInferenceSDPAModule_Utils::make_beam_idx(batch);
-    auto text_req = m_compiled_text->create_infer_request();
-    text_req.reset_state();
+
+    m_infer_request.reset_state();
 
     // --- Prefill ---
-    text_req.set_tensor(TIO::kInputIds, input_ids);
-    text_req.set_tensor(TIO::kAttentionMask, attention_mask);
-    text_req.set_tensor(TIO::kPositionIds, position_ids);
-    text_req.set_tensor(TIO::kBeamIdx, beam_idx);
+    m_infer_request.set_tensor(TIO::kInputIds, input_ids);
+    m_infer_request.set_tensor(TIO::kAttentionMask, attention_mask);
+    m_infer_request.set_tensor(TIO::kPositionIds, position_ids);
+    m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
 
     if (m_text_uses_vl_ir) {
         // Feed zero visual inputs for text-only usage of VL IR
-        text_req.set_tensor(
+        m_infer_request.set_tensor(
             TIO::kVisualEmbeds,
             LLMInferenceSDPAModule_Utils::make_zeros(ov::element::f32,
                        {batch, static_cast<size_t>(prompt_len), static_cast<size_t>(m_model_config.text.hidden_size)}));
-        text_req.set_tensor(TIO::kVisualPosMask,
+        m_infer_request.set_tensor(TIO::kVisualPosMask,
                             LLMInferenceSDPAModule_Utils::make_zeros(ov::element::boolean, {batch, static_cast<size_t>(prompt_len)}));
     }
 
     const auto t_prefill0 = std::chrono::steady_clock::now();
     {
         PROFILE(pm, "LLMInferenceSDPAModule::run_text_decode prefill infer");
-        text_req.infer();
+        m_infer_request.infer();
     }
     const auto t_prefill1 = std::chrono::steady_clock::now();
-    int64_t next_id = LLMInferenceSDPAModule_Utils::argmax_last(text_req.get_tensor(TIO::kLogits));
+    int64_t next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
 
     // --- Decode loop ---
     std::vector<int64_t> generated{next_id};
@@ -200,21 +201,21 @@ std::string LLMInferenceSDPAImpl_Qwen3_5::run_text_decode(const ov::Tensor& inpu
         auto pos =
             ov::genai::modeling::models::Qwen3_5InputPlanner::build_decode_position_ids(rope_deltas, past_len, 1);
 
-        text_req.set_tensor(TIO::kInputIds, step_ids);
-        text_req.set_tensor(TIO::kAttentionMask, step_mask);
-        text_req.set_tensor(TIO::kPositionIds, pos);
-        text_req.set_tensor(TIO::kBeamIdx, beam_idx);
+        m_infer_request.set_tensor(TIO::kInputIds, step_ids);
+        m_infer_request.set_tensor(TIO::kAttentionMask, step_mask);
+        m_infer_request.set_tensor(TIO::kPositionIds, pos);
+        m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
         if (m_text_uses_vl_ir) {
-            text_req.set_tensor(TIO::kVisualEmbeds, dec_vis);
-            text_req.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
+            m_infer_request.set_tensor(TIO::kVisualEmbeds, dec_vis);
+            m_infer_request.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
         }
 
         {
             PROFILE(pm, "LLMInferenceSDPAModule::run_text_decode step infer");
-            text_req.infer();
+            m_infer_request.infer();
         }
 
-        next_id = LLMInferenceSDPAModule_Utils::argmax_last(text_req.get_tensor(TIO::kLogits));
+        next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
         generated.push_back(next_id);
         ++decode_steps;
         ++past_len;
@@ -273,39 +274,39 @@ std::string LLMInferenceSDPAImpl_Qwen3_5::run_vl_decode(
     const int64_t prompt_len = static_cast<int64_t>(input_ids.get_shape()[1]);
 
     auto beam_idx = LLMInferenceSDPAModule_Utils::make_beam_idx(batch);
-    auto text_req = m_compiled_text->create_infer_request();
-    text_req.reset_state();
+
+    m_infer_request.reset_state();
 
     // --- Prefill ---
-    text_req.set_tensor(TIO::kInputIds, input_ids);
-    text_req.set_tensor(TIO::kAttentionMask, attention_mask);
-    text_req.set_tensor(TIO::kPositionIds, position_ids);
-    text_req.set_tensor(TIO::kBeamIdx, beam_idx);
-    text_req.set_tensor(TIO::kVisualEmbeds, visual_embeds);
-    text_req.set_tensor(TIO::kVisualPosMask, visual_pos_mask);
+    m_infer_request.set_tensor(TIO::kInputIds, input_ids);
+    m_infer_request.set_tensor(TIO::kAttentionMask, attention_mask);
+    m_infer_request.set_tensor(TIO::kPositionIds, position_ids);
+    m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
+    m_infer_request.set_tensor(TIO::kVisualEmbeds, visual_embeds);
+    m_infer_request.set_tensor(TIO::kVisualPosMask, visual_pos_mask);
     if (deepstack_embeds.has_value()) {
         for (size_t i = 0; i < deepstack_embeds->size(); i++) {
             const std::string name = std::string(ov::genai::modeling::models::Qwen3_5TextIO::kDeepstackEmbedsPrefix) +
                                      "." + std::to_string(i);
-            text_req.set_tensor(name, deepstack_embeds.value()[i]);
+            m_infer_request.set_tensor(name, deepstack_embeds.value()[i]);
         }
         ov::Tensor prefill_audio_features(
             ov::element::f32,
             {batch, input_ids.get_shape()[1], static_cast<size_t>(m_model_config.text.hidden_size)});
         std::memset(prefill_audio_features.data(), 0, prefill_audio_features.get_byte_size());
-        text_req.set_tensor("audio_features", prefill_audio_features);
+        m_infer_request.set_tensor("audio_features", prefill_audio_features);
         ov::Tensor prefill_audio_pos_mask(ov::element::boolean, {batch, input_ids.get_shape()[1]});
         std::memset(prefill_audio_pos_mask.data(), 0, prefill_audio_pos_mask.get_byte_size());
-        text_req.set_tensor("audio_pos_mask", prefill_audio_pos_mask);
+        m_infer_request.set_tensor("audio_pos_mask", prefill_audio_pos_mask);
     }
 
     const auto t_prefill0 = std::chrono::steady_clock::now();
     {
         PROFILE(pm, "LLMInferenceSDPAModule::run_vl_decode prefill infer");
-        text_req.infer();
+        m_infer_request.infer();
     }
     const auto t_prefill1 = std::chrono::steady_clock::now();
-    int64_t next_id = LLMInferenceSDPAModule_Utils::argmax_last(text_req.get_tensor(TIO::kLogits));
+    int64_t next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
 
     // --- Decode loop ---
     std::vector<int64_t> generated{next_id};
@@ -345,28 +346,28 @@ std::string LLMInferenceSDPAImpl_Qwen3_5::run_vl_decode(
             pos = ov::genai::modeling::models::Qwen3_5InputPlanner::build_decode_position_ids(rope_deltas, past_len, 1);
         } else {
             pos = ov::genai::modeling::models::Qwen3_5InputPlanner::build_decode_position_ids(rope_deltas, past_len, 1);
-            text_req.set_tensor("audio_features", decode_audio_features);
-            text_req.set_tensor("audio_pos_mask", decode_audio_pos_mask);
+            m_infer_request.set_tensor("audio_features", decode_audio_features);
+            m_infer_request.set_tensor("audio_pos_mask", decode_audio_pos_mask);
             for (size_t i = 0; i < decode_deepstack.size(); ++i) {
                 const std::string name =
                     std::string(ov::genai::modeling::models::Qwen3_5TextIO::kDeepstackEmbedsPrefix) + "." +
                     std::to_string(i);
-                text_req.set_tensor(name, decode_deepstack[i]);
+                m_infer_request.set_tensor(name, decode_deepstack[i]);
             }
         }
 
-        text_req.set_tensor(TIO::kInputIds, step_ids);
-        text_req.set_tensor(TIO::kAttentionMask, step_mask);
-        text_req.set_tensor(TIO::kPositionIds, pos);
-        text_req.set_tensor(TIO::kBeamIdx, beam_idx);
-        text_req.set_tensor(TIO::kVisualEmbeds, dec_vis);
-        text_req.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
+        m_infer_request.set_tensor(TIO::kInputIds, step_ids);
+        m_infer_request.set_tensor(TIO::kAttentionMask, step_mask);
+        m_infer_request.set_tensor(TIO::kPositionIds, pos);
+        m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
+        m_infer_request.set_tensor(TIO::kVisualEmbeds, dec_vis);
+        m_infer_request.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
 
         {
             PROFILE(pm, "LLMInferenceSDPAModule::run_vl_decode step infer");
-            text_req.infer();
+            m_infer_request.infer();
         }
-        next_id = LLMInferenceSDPAModule_Utils::argmax_last(text_req.get_tensor(TIO::kLogits));
+        next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
         generated.push_back(next_id);
         ++decode_steps;
         ++past_len;

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
@@ -37,7 +37,8 @@ LLMInferenceSDPAImpl_Qwen3Omni::LLMInferenceSDPAImpl_Qwen3Omni(const IBaseModule
     }
 
     auto llm_model = ov::genai::utils::singleton_core().read_model(m_models_ir);
-    m_compiled_text = ov::genai::utils::singleton_core().compile_model(llm_model, m_device, properties);
+    auto compiled_model = ov::genai::utils::singleton_core().compile_model(llm_model, m_device, properties);
+    m_infer_request = compiled_model.create_infer_request();
 }
 
 LLMInferenceSDPAModule::InputsParams::PTR LLMInferenceSDPAImpl_Qwen3Omni::parse_inputs(
@@ -111,24 +112,23 @@ std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
     const int64_t prompt_len = static_cast<int64_t>(input_ids.get_shape()[1]);
 
     auto beam_idx = LLMInferenceSDPAModule_Utils::make_beam_idx(batch);
-    auto text_req = m_compiled_text->create_infer_request();
-    text_req.reset_state();
+    m_infer_request.reset_state();
 
     // --- Prefill ---
-    text_req.set_tensor(TIO::kInputIds, input_ids);
-    text_req.set_tensor(TIO::kAttentionMask, attention_mask);
-    text_req.set_tensor(TIO::kPositionIds, position_ids);
-    text_req.set_tensor(TIO::kBeamIdx, beam_idx);
+    m_infer_request.set_tensor(TIO::kInputIds, input_ids);
+    m_infer_request.set_tensor(TIO::kAttentionMask, attention_mask);
+    m_infer_request.set_tensor(TIO::kPositionIds, position_ids);
+    m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
     if (visual_embeds.has_value() && visual_pos_mask.has_value()) {
-        text_req.set_tensor(TIO::kVisualEmbeds, visual_embeds.value());
-        text_req.set_tensor(TIO::kVisualPosMask, visual_pos_mask.value());
+        m_infer_request.set_tensor(TIO::kVisualEmbeds, visual_embeds.value());
+        m_infer_request.set_tensor(TIO::kVisualPosMask, visual_pos_mask.value());
     } else {
-        text_req.set_tensor(
+        m_infer_request.set_tensor(
             TIO::kVisualEmbeds,
             LLMInferenceSDPAModule_Utils::make_zeros(
                 ov::element::f32,
                 {batch, static_cast<size_t>(prompt_len), static_cast<size_t>(model_config.thinker.text.hidden_size)}));
-        text_req.set_tensor(
+        m_infer_request.set_tensor(
             TIO::kVisualPosMask,
             LLMInferenceSDPAModule_Utils::make_zeros(ov::element::boolean, {batch, static_cast<size_t>(prompt_len)}));
     }
@@ -137,14 +137,14 @@ std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
             const std::string name =
                 std::string(ov::genai::modeling::models::Qwen3OmniVisionIO::kDeepstackEmbedsPrefix) + "." +
                 std::to_string(i);
-            text_req.set_tensor(name, deepstack_embeds.value()[i]);
+            m_infer_request.set_tensor(name, deepstack_embeds.value()[i]);
         }
     } else {
         for (size_t i = 0; i < model_config.thinker.vision.deepstack_visual_indexes.size(); i++) {
             const std::string name =
                 std::string(ov::genai::modeling::models::Qwen3OmniVisionIO::kDeepstackEmbedsPrefix) + "." +
                 std::to_string(i);
-            text_req.set_tensor(
+            m_infer_request.set_tensor(
                 name,
                 LLMInferenceSDPAModule_Utils::make_zeros(ov::element::f32,
                                                          {batch,
@@ -153,26 +153,26 @@ std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
         }
     }
     if (audio_embeds.has_value() && audio_pos_mask.has_value()) {
-        text_req.set_tensor(TIO::kAudioFeatures, audio_embeds.value());
-        text_req.set_tensor(TIO::kAudioPosMask, audio_pos_mask.value());
+        m_infer_request.set_tensor(TIO::kAudioFeatures, audio_embeds.value());
+        m_infer_request.set_tensor(TIO::kAudioPosMask, audio_pos_mask.value());
     } else {
         ov::Tensor prefill_audio_features(
             ov::element::f32,
             {batch, input_ids.get_shape()[1], static_cast<size_t>(model_config.thinker.text.hidden_size)});
         std::memset(prefill_audio_features.data(), 0, prefill_audio_features.get_byte_size());
-        text_req.set_tensor(TIO::kAudioFeatures, prefill_audio_features);
+        m_infer_request.set_tensor(TIO::kAudioFeatures, prefill_audio_features);
         ov::Tensor prefill_audio_pos_mask(ov::element::boolean, {batch, input_ids.get_shape()[1]});
         std::memset(prefill_audio_pos_mask.data(), 0, prefill_audio_pos_mask.get_byte_size());
-        text_req.set_tensor(TIO::kAudioPosMask, prefill_audio_pos_mask);
+        m_infer_request.set_tensor(TIO::kAudioPosMask, prefill_audio_pos_mask);
     }
 
     const auto t_prefill0 = std::chrono::steady_clock::now();
     {
         PROFILE(pm, "LLMInferenceSDPAModule::run_text_decode prefill infer");
-        text_req.infer();
+        m_infer_request.infer();
     }
     const auto t_prefill1 = std::chrono::steady_clock::now();
-    int64_t next_id = LLMInferenceSDPAModule_Utils::argmax_last(text_req.get_tensor(TIO::kLogits));
+    int64_t next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
 
     // --- Decode loop ---
     std::vector<int64_t> generated{next_id};
@@ -212,26 +212,26 @@ std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
         ov::Tensor pos =
             ov::genai::modeling::models::Qwen3OmniInputPlanner::build_decode_position_ids(rope_deltas, past_len, 1);
 
-        text_req.set_tensor(TIO::kInputIds, step_ids);
-        text_req.set_tensor(TIO::kAttentionMask, step_mask);
-        text_req.set_tensor(TIO::kPositionIds, pos);
-        text_req.set_tensor(TIO::kBeamIdx, beam_idx);
-        text_req.set_tensor(TIO::kVisualEmbeds, dec_vis);
-        text_req.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
-        text_req.set_tensor(TIO::kAudioFeatures, decode_audio_features);
-        text_req.set_tensor(TIO::kAudioPosMask, decode_audio_pos_mask);
+        m_infer_request.set_tensor(TIO::kInputIds, step_ids);
+        m_infer_request.set_tensor(TIO::kAttentionMask, step_mask);
+        m_infer_request.set_tensor(TIO::kPositionIds, pos);
+        m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
+        m_infer_request.set_tensor(TIO::kVisualEmbeds, dec_vis);
+        m_infer_request.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
+        m_infer_request.set_tensor(TIO::kAudioFeatures, decode_audio_features);
+        m_infer_request.set_tensor(TIO::kAudioPosMask, decode_audio_pos_mask);
         for (size_t i = 0; i < decode_deepstack.size(); ++i) {
             const std::string name = std::string(ov::genai::modeling::models::Qwen3VLTextIO::kDeepstackEmbedsPrefix) +
                                      "." + std::to_string(i);
-            text_req.set_tensor(name, decode_deepstack[i]);
+            m_infer_request.set_tensor(name, decode_deepstack[i]);
         }
 
         {
             PROFILE(pm, "LLMInferenceSDPAModule::run_qwen3_omni_decode step infer");
-            text_req.infer();
+            m_infer_request.infer();
         }
 
-        next_id = LLMInferenceSDPAModule_Utils::argmax_last(text_req.get_tensor(TIO::kLogits));
+        next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
         generated.push_back(next_id);
         ++decode_steps;
         ++past_len;


### PR DESCRIPTION
This pull request refactors the inference request handling for LLM inference modules, specifically for Qwen3.5 and Qwen3Omni models. The main improvement is switching from creating a new infer request for each decoding step to maintaining a single persistent `m_infer_request` instance throughout the module's lifecycle. This change streamlines the code, reduces overhead, and ensures better resource management during inference.

### Refactoring of Infer Request Handling

* Changed the member variable from an optional compiled model (`m_compiled_text`) to a persistent infer request (`m_infer_request`) in `LLMInferenceSDPAModule`, removing the need to create a new infer request for each run. (`src/cpp/src/module_genai/modules/md_llm_inference_sdpa/md_llm_inference_sdpa.hpp`)
* Updated constructors in both `LLMInferenceSDPAImpl_Qwen3_5` and `LLMInferenceSDPAImpl_Qwen3Omni` to initialize `m_infer_request` from the compiled model, instead of storing the compiled model itself. (`src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_5.cpp`, `src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp`) [[1]](diffhunk://#diff-86ec68d1aaa7a347181a6ed27ae61ccba9e890a00a2e44a34502d36077f8653fL108-R109) [[2]](diffhunk://#diff-b17db1e1f0de5dd9ed6880137f49c0c4c66901baaf4320fc93d96d3569ffddf9L40-R41)

### Code Simplification in Decoding Functions

* Replaced all per-step creation of infer requests with reuse of the persistent `m_infer_request` in all decode functions (`run_text_decode`, `run_vl_decode`, `run_qwen3_omni_decode`), including tensor setting and inference calls. (`src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_5.cpp`, `src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp`) [[1]](diffhunk://#diff-86ec68d1aaa7a347181a6ed27ae61ccba9e890a00a2e44a34502d36077f8653fL148-R174) [[2]](diffhunk://#diff-86ec68d1aaa7a347181a6ed27ae61ccba9e890a00a2e44a34502d36077f8653fL203-R218) [[3]](diffhunk://#diff-86ec68d1aaa7a347181a6ed27ae61ccba9e890a00a2e44a34502d36077f8653fL276-R309) [[4]](diffhunk://#diff-86ec68d1aaa7a347181a6ed27ae61ccba9e890a00a2e44a34502d36077f8653fL348-R370) [[5]](diffhunk://#diff-b17db1e1f0de5dd9ed6880137f49c0c4c66901baaf4320fc93d96d3569ffddf9L114-R131) [[6]](diffhunk://#diff-b17db1e1f0de5dd9ed6880137f49c0c4c66901baaf4320fc93d96d3569ffddf9L140-R147) [[7]](diffhunk://#diff-b17db1e1f0de5dd9ed6880137f49c0c4c66901baaf4320fc93d96d3569ffddf9L156-R175) [[8]](diffhunk://#diff-b17db1e1f0de5dd9ed6880137f49c0c4c66901baaf4320fc93d96d3569ffddf9L215-R234)

These changes make the inference code more efficient and easier to maintain by eliminating redundant infer request creation and centralizing state management.