### PR TITLE
Fix Windows MSVC build errors

### DIFF
--- a/samples/cpp/module_genai/utils/vision_utils.cpp
+++ b/samples/cpp/module_genai/utils/vision_utils.cpp
@@ -134,8 +134,8 @@ std::pair<int, int> smart_resize_video(int height, int width,
 int smart_nframes(int total_frames, double video_fps,
                   float target_fps = 2.0f, int min_frames = 4, int max_frames = 768) {
     constexpr int FRAME_FACTOR = 2;
-    auto floor2 = [](double v) { return (int)(std::floor(v / FRAME_FACTOR) * FRAME_FACTOR); };
-    auto ceil2  = [](double v) { return (int)(std::ceil(v  / FRAME_FACTOR) * FRAME_FACTOR); };
+    auto floor2 = [FRAME_FACTOR](double v) { return (int)(std::floor(v / FRAME_FACTOR) * FRAME_FACTOR); };
+    auto ceil2  = [FRAME_FACTOR](double v) { return (int)(std::ceil(v  / FRAME_FACTOR) * FRAME_FACTOR); };
 
     int min_f   = std::max(FRAME_FACTOR, ceil2(min_frames));
     int max_f   = std::max(FRAME_FACTOR, floor2(std::min(max_frames, total_frames)));

--- a/src/cpp/src/modeling/samples/CMakeLists.txt
+++ b/src/cpp/src/modeling/samples/CMakeLists.txt
@@ -19,7 +19,8 @@ target_include_directories(modeling_qwen3_vl PRIVATE
     $<TARGET_PROPERTY:openvino::genai,INTERFACE_INCLUDE_DIRECTORIES>)
 
 target_link_libraries(modeling_qwen3_vl PRIVATE
-    $<TARGET_PROPERTY:openvino_genai_obj,LINK_LIBRARIES>)
+    $<TARGET_PROPERTY:openvino_genai_obj,LINK_LIBRARIES>
+    ${YAML_CPP_TARGET})
 
 target_compile_definitions(modeling_qwen3_vl PRIVATE
     openvino_genai_EXPORTS)


### PR DESCRIPTION
1. Fix lambda capture in smart_nframes() (vision_utils.cpp): MSVC requires explicit capture of constexpr variable FRAME_FACTOR in lambdas. Changed [] to [FRAME_FACTOR] for floor2/ceil2 lambdas.

2. Fix yaml-cpp linker errors for modeling_qwen3_vl target: Add missing  to target_link_libraries. The yaml-cpp symbols were not propagated through openvino_genai_obj LINK_LIBRARIES property, causing LNK2019 unresolved externals.

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] This PR follows [GenAI Contributing guidelines](https://github.com/openvinotoolkit/openvino.genai?tab=contributing-ov-file#contributing). <!-- Always follow them. If there are deviations, explain what and why. -->
- [ ] Tests have been updated or added to cover the new code. <!-- Specify exactly which tests were added or updated. If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This PR fully addresses the ticket. <!--- If not, explain clearly what is covered and what is not. If follow-up pull requests are needed, specify in the description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. If the documentation is updated in a separate PR, clearly specify it. -->
