### PR TITLE
Fix specification checking issue

### DIFF
--- a/samples/cpp/module_genai/md_omni.cpp
+++ b/samples/cpp/module_genai/md_omni.cpp
@@ -91,6 +91,9 @@ int main(int argc, char* argv[]) {
         bool perf = std::stoi(utils::get_input_arg(argc, argv, "-perf", std::string("0")));
         bool use_tts = std::stoi(utils::get_input_arg(argc, argv, "-tts", std::string("0"))) != 0;
 
+        std::cout << "Config YAML: " << std::endl;
+        std::cout << "  - " << config_path << std::endl;
+
         utils::OmniInputParams input_params = utils::parse_omni_input_params(argc, argv);
         ov::AnyMap inputs = parse_inputs_for_omni(input_params);
 
@@ -119,9 +122,7 @@ int main(int argc, char* argv[]) {
 
         std::cout << "[Generation] Running main generation..." << std::endl;
         auto t1 = std::chrono::high_resolution_clock::now();
-
         pipe.generate(inputs);
-
         auto t2 = std::chrono::high_resolution_clock::now();
         if (perf) {
             auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/md_llm_inference_sdpa.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/md_llm_inference_sdpa.cpp
@@ -38,6 +38,8 @@ const ModuleSpec& LLMInferenceSDPAModule::get_spec() {
     static const ModuleSpec spec = []() {
         ModuleSpec s("LLMInferenceSDPAModule", "llm_inference_sdpa");
         s.add_input("input_ids", {DataType::OVTensor});
+        s.add_input("position_ids", {DataType::OVTensor}, true);
+        s.add_input("rope_delta", {DataType::OVTensor}, true);
         s.add_input("visual_embeds", {DataType::OVTensor}, true);
         s.add_input("visual_pos_mask", {DataType::OVTensor}, true);
         s.add_input("grid_thw", {DataType::OVTensor}, true);

--- a/src/cpp/src/module_genai/pipeline/module_base.cpp
+++ b/src/cpp/src/module_genai/pipeline/module_base.cpp
@@ -179,30 +179,41 @@ bool IBaseModule::check_bool_optional_param(const std::string& param_name, const
 }
 
 void IBaseModule::check_params_with_spec(const ModuleSpec& spec) {
+    auto error_tip = [this](const std::string& name) {
+        return "Module[" + ModuleTypeConverter::toString(module_desc->type) + "(" + module_desc->name + ")" + "]: '" +
+               name + "' ";
+    };
+
     // Check Inputs
     const auto& inputs = module_desc->inputs;
     for (const auto& input : inputs) {
         // Find input.name in spec.inputs()
-        auto it = std::find_if(spec.inputs().begin(), spec.inputs().end(),
-                               [&input](const auto& input_spec) { return input_spec.name == input.name; });
-        OPENVINO_ASSERT (it != spec.inputs().end(), "Module[" + module_desc->name + "]: input '" + input.name + "' is not defined in ModuleSpec");
+        auto it = std::find_if(spec.inputs().begin(), spec.inputs().end(), [&input](const auto& input_spec) {
+            return input_spec.name == input.name;
+        });
+        OPENVINO_ASSERT(it != spec.inputs().end(), error_tip(input.name) + "is not defined in ModuleSpec");
+
         // Check input.dt_type in it->supported_types
         auto& supported_types = it->supported_types;
-        OPENVINO_ASSERT(std::find(supported_types.begin(), supported_types.end(), input.dt_type) != supported_types.end(),
-                        "Module[" + module_desc->name + "]: input '" + input.name + "' has unsupported data type");
+        OPENVINO_ASSERT(
+            std::find(supported_types.begin(), supported_types.end(), input.dt_type) != supported_types.end(),
+            error_tip(input.name) + "has unsupported data type");
     }
 
     // Check Outputs
     const auto& outputs = module_desc->outputs;
     for (const auto& output : outputs) {
         // Find output.name in spec.outputs()
-        auto it = std::find_if(spec.outputs().begin(), spec.outputs().end(),
-                               [&output](const auto& output_spec) { return output_spec.name == output.name; });
-        OPENVINO_ASSERT (it != spec.outputs().end(), "Module[" + module_desc->name + "]: output '" + output.name + "' is not defined in ModuleSpec");
+        auto it = std::find_if(spec.outputs().begin(), spec.outputs().end(), [&output](const auto& output_spec) {
+            return output_spec.name == output.name;
+        });
+        OPENVINO_ASSERT(it != spec.outputs().end(), error_tip(output.name) + "is not defined in ModuleSpec");
+
         // Check output.dt_type in it->supported_types
         auto& supported_types = it->supported_types;
-        OPENVINO_ASSERT(std::find(supported_types.begin(), supported_types.end(), output.dt_type) != supported_types.end(),
-                        "Module[" + module_desc->name + "]: output '" + output.name + "' has unsupported data type");
+        OPENVINO_ASSERT(
+            std::find(supported_types.begin(), supported_types.end(), output.dt_type) != supported_types.end(),
+            error_tip(output.name) + "has unsupported data type");
     }
 }
 


### PR DESCRIPTION
This pull request introduces improvements to module specification validation, enhances error messages for parameter checking, and adds new optional inputs to the `LLMInferenceSDPAModule`. Additionally, it improves logging in the sample application and contains minor code cleanups.

### Module specification and validation enhancements

* Improved error messages in `IBaseModule::check_params_with_spec` by introducing a helper lambda to provide more informative context when input or output parameters do not match the module specification. This makes debugging misconfigurations easier.

### Module input specification updates

* Added two new optional inputs, `position_ids` and `rope_delta`, to the `LLMInferenceSDPAModule` specification, allowing for greater flexibility in model input handling.

### Sample application improvements

* Added logging of the config YAML path at the start of `main` in `md_omni.cpp` to aid in debugging and reproducibility.

### Code cleanup

* Minor cleanup of spacing and blank lines in the generation timing section of `md_omni.cpp` for better readability.