### PR TITLE
Refactor and fix issues in split model implementation

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -5,6 +5,7 @@
 file(GLOB_RECURSE SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")
 file(GLOB_RECURSE modeling_samples_src "${CMAKE_CURRENT_SOURCE_DIR}/src/modeling/samples/*.cpp")
 list(REMOVE_ITEM SOURCE_FILES ${modeling_samples_src})
+list(APPEND SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/modeling/samples/utils/split_text_model.cpp")
 file(GLOB_RECURSE modeling_private_samples_src "${CMAKE_CURRENT_SOURCE_DIR}/src/modeling_private/samples/*.cpp")
 list(REMOVE_ITEM SOURCE_FILES ${modeling_private_samples_src})
 list(FILTER SOURCE_FILES EXCLUDE REGEX ".*[/\\]safetensors_utils[/\\].*")

--- a/src/cpp/src/modeling/samples/CMakeLists.txt
+++ b/src/cpp/src/modeling/samples/CMakeLists.txt
@@ -27,6 +27,28 @@ target_compile_definitions(modeling_qwen3_vl PRIVATE
 
 add_dependencies(modeling_qwen3_vl openvino_genai)
 
+
+add_executable(test_split_text_model
+    test_split_text_model.cpp
+    "${OpenVINOGenAI_SOURCE_DIR}/samples/cpp/visual_language_chat/load_image.cpp"
+    $<TARGET_OBJECTS:openvino_genai_obj>)
+
+target_include_directories(test_split_text_model PRIVATE
+    "${CMAKE_BINARY_DIR}"
+    "${OpenVINOGenAI_SOURCE_DIR}/samples/cpp/visual_language_chat"
+    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src"
+    "${OpenVINOGenAI_SOURCE_DIR}/openvino/thirdparty/json/nlohmann_json/include"
+    $<TARGET_PROPERTY:openvino::genai,INTERFACE_INCLUDE_DIRECTORIES>)
+
+target_link_libraries(test_split_text_model PRIVATE
+    $<TARGET_PROPERTY:openvino_genai_obj,LINK_LIBRARIES>
+    ${YAML_CPP_TARGET})
+
+target_compile_definitions(test_split_text_model PRIVATE
+    openvino_genai_EXPORTS)
+
+add_dependencies(test_split_text_model openvino_genai)
+
 # Standalone video frame extraction tool (replaces Python extract_video_frames.py)
 find_package(OpenCV QUIET COMPONENTS videoio imgcodecs imgproc core)
 if(OpenCV_FOUND)

--- a/src/cpp/src/modeling/samples/CMakeLists.txt
+++ b/src/cpp/src/modeling/samples/CMakeLists.txt
@@ -30,7 +30,6 @@ add_dependencies(modeling_qwen3_vl openvino_genai)
 
 add_executable(test_split_text_model
     test_split_text_model.cpp
-    utils/split_text_model.cpp
     "${OpenVINOGenAI_SOURCE_DIR}/samples/cpp/visual_language_chat/load_image.cpp"
     $<TARGET_OBJECTS:openvino_genai_obj>)
 

--- a/src/cpp/src/modeling/samples/CMakeLists.txt
+++ b/src/cpp/src/modeling/samples/CMakeLists.txt
@@ -30,6 +30,7 @@ add_dependencies(modeling_qwen3_vl openvino_genai)
 
 add_executable(test_split_text_model
     test_split_text_model.cpp
+    utils/split_text_model.cpp
     "${OpenVINOGenAI_SOURCE_DIR}/samples/cpp/visual_language_chat/load_image.cpp"
     $<TARGET_OBJECTS:openvino_genai_obj>)
 

--- a/src/cpp/src/modeling/samples/test_split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/test_split_text_model.cpp
@@ -7,6 +7,7 @@
 
 int main() {
     ov::Core core;
+    core.get_versions("CPU");
 
     std::string text_model_path_1 = "/mnt/xiping/mygithub/modular_genai/openvino.genai/tests/module_genai/cpp/test_models/Qwen3-Omni-4B-Instruct-multilingual-int4/qwen3_omni_text_model.xml";
     // Load original model, in real case, it should be loaded from file.
@@ -19,6 +20,7 @@ int main() {
     for (const auto& [name, model] : sub_models) {
         std::cout << "Sub-model name: " << name << std::endl;
     }
+
 
     return 0;
 }

--- a/src/cpp/src/modeling/samples/test_split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/test_split_text_model.cpp
@@ -1,0 +1,24 @@
+#include <openvino/openvino.hpp>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "utils/split_text_model.hpp"
+
+int main() {
+    ov::Core core;
+
+    std::string text_model_path_1 = "/mnt/xiping/mygithub/modular_genai/openvino.genai/tests/module_genai/cpp/test_models/Qwen3-Omni-4B-Instruct-multilingual-int4/qwen3_omni_text_model.xml";
+    // Load original model, in real case, it should be loaded from file.
+    auto original_model = core.read_model(text_model_path_1);
+
+    // Call the split_text_model function with dummy node names, in real case, it should be the actual node names in the model.
+    auto sub_models = ov::genai::modeling::samples::split_text_model(*original_model, "input_ids", "visual_embeds", "audio_features");
+
+    // Print the sub-models' names.
+    for (const auto& [name, model] : sub_models) {
+        std::cout << "Sub-model name: " << name << std::endl;
+    }
+
+    return 0;
+}

--- a/src/cpp/src/modeling/samples/test_split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/test_split_text_model.cpp
@@ -13,12 +13,26 @@ int main() {
     // Load original model, in real case, it should be loaded from file.
     auto original_model = core.read_model(text_model_path_1);
 
-    // Call the split_text_model function with dummy node names, in real case, it should be the actual node names in the model.
+    // Slipt the original text model into sub-models based on input_ids, visual_embeds and audio_embeds.
+    // Just for compatable with ContinueBatching inference.
+    auto t1 = std::chrono::high_resolution_clock::now();
     auto sub_models = ov::genai::modeling::samples::split_text_model(*original_model, "input_ids", "visual_embeds", "audio_features");
+    auto t2 = std::chrono::high_resolution_clock::now();
+    std::cout << "Split text model time: " << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count() << " ms" << std::endl;
 
     // Print the sub-models' names.
     for (const auto& [name, model] : sub_models) {
         std::cout << "Sub-model name: " << name << std::endl;
+        // Print the sub-model's parameters' names.
+        for (const auto& parameter : model->get_parameters()) {
+            std::cout << " - Parameter name: " << parameter->get_friendly_name() << std::endl;
+        }
+        for (const auto& result : model->get_results()) {
+            std::cout << " - Result name: " << result->get_friendly_name() << std::endl;
+        }
+        // Serialize the sub-models to files, in real case, it can be used for inference directly.
+        std::cout << "Serialize sub-model: " << name << std::endl;
+        ov::serialize(model, name + ".xml", name + ".bin");
     }
 
 

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -1,5 +1,7 @@
 #include "split_text_model.hpp"
 
+#include <algorithm>
+
 namespace ov::genai::modeling::samples {
 
 // DFS search for the selece node.
@@ -143,6 +145,7 @@ std::set<std::shared_ptr<ov::Node>> find_parameters(const std::shared_ptr<ov::No
 std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_model,
                                                       std::shared_ptr<ov::Node> split_node,
                                                       std::shared_ptr<ov::Node> input_ids_node,
+                                                      const std::set<std::shared_ptr<ov::Node>>& parameters,
                                                       const std::shared_ptr<ov::Node>& gather_node) {
     OPENVINO_ASSERT(gather_node != nullptr, "find_embedding_merge_model: gather_node is null");
     OPENVINO_ASSERT(split_node != nullptr, "find_embedding_merge_model: split_node is null");
@@ -151,10 +154,14 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
     // gather_node's output as new model's input.
     auto text_embedding_input = std::make_shared<ov::op::v0::Parameter>(gather_node->get_element_type(),
                                                                         gather_node->get_output_partial_shape(0));
-    text_embedding_input->set_friendly_name("text_embedding_input");
+    text_embedding_input->set_friendly_name("text_embeds");
     ov::ParameterVector new_parameters{text_embedding_input};
-    // Keep all original parameters except input_ids to preserve graph dependencies.
-    for (const auto& parameter : original_model.get_parameters()) {
+    // Use exact nodes referenced by split_node subgraph to avoid undeclared-parameter mismatch.
+    for (const auto& parameter_node : parameters) {
+        auto parameter = ov::as_type_ptr<ov::op::v0::Parameter>(parameter_node);
+        if (parameter == nullptr) {
+            continue;
+        }
         if (parameter->get_friendly_name() == input_ids_node->get_friendly_name()) {
             continue;
         }
@@ -250,11 +257,13 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         auto text_embed_model = std::make_shared<ov::Model>(results,
                                                             ov::ParameterVector{input_ids_node},
                                                             "input_ids_embed_model");
+        ov::serialize(text_embed_model, "text_embed_model.xml", "text_embed_model.bin");
         result["text_embed_model"] = text_embed_model;
     }
 
     // Find merger model.
-    auto embedding_merge_model = find_embedding_merge_model(original_model, split_node, input_ids_node, gather_node);
+    auto embedding_merge_model =
+        find_embedding_merge_model(original_model, split_node, input_ids_node, parameters, gather_node);
     result["embedding_merge_model"] = embedding_merge_model;
 
     // Get LLM model with embedding input.
@@ -262,12 +271,18 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         // Replace original model's input with split node's output, and replace original model's output with split
         // node's output.
         ov::ParameterVector new_parameters;
+        const auto& embedding_merge_parameters = embedding_merge_model->get_parameters();
         for (const auto& parameter : original_model.get_parameters()) {
+            // Skip input_ids node, as it will be replaced by the embedding input. To preserve graph dependencies, keep all other original parameters.
             if (parameter->get_friendly_name() == input_ids_node->get_friendly_name()) {
                 continue;
             }
-            new_parameters.push_back(std::make_shared<ov::op::v0::Parameter>(parameter->get_element_type(),
-                                                                             parameter->get_output_partial_shape(0)));
+            // Skip Model(embedding_merge_model)'s parameters, as they will be replaced by the embedding input.
+            if (std::find(embedding_merge_parameters.begin(), embedding_merge_parameters.end(), parameter) !=
+                embedding_merge_parameters.end()) {
+                continue;
+            }
+            new_parameters.push_back(parameter);
         }
 
         auto embedding_input = std::make_shared<ov::op::v0::Parameter>(split_node->get_element_type(),

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -152,6 +152,7 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
     // gather_node's output as new model's input.
     auto text_embedding_input = std::make_shared<ov::op::v0::Parameter>(gather_node->get_element_type(),
                                                                         gather_node->get_output_partial_shape(0));
+    text_embedding_input->set_friendly_name("text_embedding_input");
     ov::ParameterVector new_parameters{text_embedding_input};
     for (const auto& parameter : parameters) {
         if (parameter->get_friendly_name() == input_ids_node->get_friendly_name()) {
@@ -164,13 +165,9 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
         new_parameters.push_back(parameter_node);
     }
 
-    // replace gather_node->output->input to text_embedding_input, only need replace current edge.
+    // replace gather_node output consumers with text_embedding_input.
     for (const auto& output : gather_node->outputs()) {
         for (auto target_input : output.get_target_inputs()) {
-            const auto* next_node = target_input.get_node();
-            if (next_node != split_node.get()) {
-                continue;
-            }
             target_input.replace_source_output(text_embedding_input->output(0));
         }
     }

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -13,8 +13,10 @@ std::shared_ptr<ov::Node> dfs_search_select_node(const std::shared_ptr<ov::Node>
     }
     for (const auto& output : current_node->outputs()) {
         for (const auto& target_input : output.get_target_inputs()) {
-            const auto& next_node = target_input.get_node();
-            auto result = dfs_search_select_node(next_node, max_search_depth - 1);
+            const auto* next_node = target_input.get_node();
+            auto result =
+                dfs_search_select_node(std::const_pointer_cast<ov::Node>(next_node->shared_from_this()),
+                                       max_search_depth - 1);
             if (result != nullptr) {
                 return result;
             }
@@ -25,31 +27,36 @@ std::shared_ptr<ov::Node> dfs_search_select_node(const std::shared_ptr<ov::Node>
 
 std::shared_ptr<ov::Node> dfs_search_gather_node(const std::shared_ptr<ov::Node>& current_node, int max_search_depth) {
     if (max_search_depth < 0) {
+        std::cout << "DFS search gather node reach max search depth, current node: " << current_node->get_friendly_name() << std::endl;
         return nullptr;
     }
     // Name is not fix, just check the type is "Gather"
     if (current_node->get_type_name() == std::string("Gather")) {
         return current_node;
     }
-    // Towards parent node searching
-    for (const auto& input : current_node->inputs()) {
-        const auto& next_node = input.get_source_output().get_node();
-        auto result = dfs_search_gather_node(next_node, max_search_depth - 1);
-        if (result != nullptr) {
-            return result;
+    // Towards son node.
+    for (const auto& output : current_node->outputs()) {
+        for (const auto& target_input : output.get_target_inputs()) {
+            const auto* next_node = target_input.get_node();
+            auto result = dfs_search_gather_node(std::const_pointer_cast<ov::Node>(next_node->shared_from_this()),
+                                                 max_search_depth - 1);
+            if (result != nullptr) {
+                return result;
+            }
         }
     }
-}
-return nullptr;
+    return nullptr;
 }
 
-std::shared_ptr<ov::Node> find_parameter_node_by_name(const ov::Model& model, const std::string& parameter_name) {
-    std::shared_ptr<ov::Node> parameter_node = nullptr;
-    model.get_parameters().for_each([&](const ov::Output<const ov::Node>& parameter) {
-        if (parameter.get_node()->get_friendly_name() == parameter_name) {
-            parameter_node = parameter.get_node_shared_ptr();
+std::shared_ptr<ov::op::v0::Parameter> find_parameter_node_by_name(const ov::Model& model,
+                                                                    const std::string& parameter_name) {
+    std::shared_ptr<ov::op::v0::Parameter> parameter_node = nullptr;
+    for (const auto& parameter : model.get_parameters()) {
+        if (parameter->get_friendly_name() == parameter_name) {
+            parameter_node = parameter;
+            break;
         }
-    });
+    }
     return parameter_node;
 }
 
@@ -61,9 +68,9 @@ std::shared_ptr<ov::Node> find_last_select_node(std::shared_ptr<ov::Node> select
         bool found_next_select = false;
         for (const auto& output : last_select_node->outputs()) {
             for (const auto& target_input : output.get_target_inputs()) {
-                const auto& next_node = target_input.get_node();
+                const auto* next_node = target_input.get_node();
                 if (next_node->get_type_name() == std::string("Select")) {
-                    last_select_node = next_node;
+                    last_select_node = std::const_pointer_cast<ov::Node>(next_node->shared_from_this());
                     found_next_select = true;
                     break;
                 }
@@ -85,11 +92,13 @@ std::shared_ptr<ov::Node> find_last_select_node(std::shared_ptr<ov::Node> select
 // to the same select node. Pattern 3: If "input_ids" has 2 sons in the graph, if one of the sons is a "shapeof"
 // node. The "gather" node should be between the other son and the select node. Pattern 4: Search max deep should be
 // less than 10, to avoid wrong split point from other branches.
-std::shared_ptr<ov::Node> search_split_point(const ov::Model& original_model,
-                                             const std::shared_ptr<ov::Node>& input_node,
+std::shared_ptr<ov::Node> search_split_point(const std::shared_ptr<ov::Node>& input_node,
                                              const int max_search_depth = 10) {
     // Step 1: DFS search for the select node with the expected pattern
     auto select_node = dfs_search_select_node(input_node, max_search_depth);
+    if (select_node == nullptr) {
+        return nullptr;
+    }
     auto last_select_node = find_last_select_node(select_node);
 
     return last_select_node;
@@ -121,7 +130,7 @@ std::set<std::shared_ptr<ov::Node>> find_parameters(const std::shared_ptr<ov::No
             parameters.insert(current_node);
         }
         for (const auto& input : current_node->inputs()) {
-            const auto& next_node = input.get_source_output().get_node();
+            const auto next_node = input.get_source_output().get_node_shared_ptr();
             stack.push_back(next_node);
         }
     }
@@ -148,18 +157,21 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
         if (parameter->get_friendly_name() == input_ids_node->get_friendly_name()) {
             continue;
         }
-        new_parameters.push_back(std::make_shared<ov::op::v0::Parameter>(parameter->get_element_type(),
-                                                                         parameter->get_output_partial_shape(0)));
+        auto parameter_node = ov::as_type_ptr<ov::op::v0::Parameter>(parameter);
+        OPENVINO_ASSERT(parameter_node != nullptr,
+                        "find_embedding_merge_model: non-Parameter node in parameter set: ",
+                        parameter->get_friendly_name());
+        new_parameters.push_back(parameter_node);
     }
 
     // replace gather_node->output->input to text_embedding_input, only need replace current edge.
     for (const auto& output : gather_node->outputs()) {
-        for (const auto& target_input : output.get_target_inputs()) {
-            const auto& next_node = target_input.get_node();
-            if (next_node->get_friendly_name() != gather_node->get_friendly_name()) {
+        for (auto target_input : output.get_target_inputs()) {
+            const auto* next_node = target_input.get_node();
+            if (next_node != split_node.get()) {
                 continue;
             }
-            next_node->input(target_input.get_index()).replace_source_output(text_embedding_input->output(0));
+            target_input.replace_source_output(text_embedding_input->output(0));
         }
     }
 
@@ -178,20 +190,25 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
 
     // Find split point based on input_ids.
     auto input_ids_node = find_parameter_node_by_name(original_model, input_ids_node_name);
-    auto input_ids_select_node = search_split_point(original_model, input_ids_node, 10);
+    auto input_ids_select_node = search_split_point(input_ids_node, 10);
     if (input_ids_select_node == nullptr) {
+        std::cout << "Cannot find split point based on input_ids node: " << input_ids_node_name << std::endl;
         return {};
     }
 
     // Find split point based on visual_embeds.
     if (!visual_embeds_node_name.empty()) {
         auto visual_embeds_node = find_parameter_node_by_name(original_model, visual_embeds_node_name);
-        auto visual_embeds_select_node = dfs_search_select_node(visual_embeds_node, 5);
+        auto visual_embeds_select_node = search_split_point(visual_embeds_node, 5);
         if (visual_embeds_select_node == nullptr) {
+            std::cout << "Cannot find select node based on visual_embeds node: " << visual_embeds_node_name << std::endl;
             return {};
         }
         // Check if input_ids_select_node and visual_embeds_select_node are the same node, if not, return empty.
         if (input_ids_select_node->get_friendly_name() != visual_embeds_select_node->get_friendly_name()) {
+            std::cout << "The select node based on input_ids and visual_embeds are different, input_ids_select_node: "
+                      << input_ids_select_node->get_friendly_name()
+                      << ", visual_embeds_select_node: " << visual_embeds_select_node->get_friendly_name() << std::endl;
             return {};
         }
     }
@@ -199,12 +216,16 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
     // Find split point based on audio_embeds.
     if (!audio_embeds_node_name.empty()) {
         auto audio_embeds_node = find_parameter_node_by_name(original_model, audio_embeds_node_name);
-        auto audio_embeds_select_node = dfs_search_select_node(audio_embeds_node, 5);
+        auto audio_embeds_select_node = search_split_point(audio_embeds_node, 5);
         if (audio_embeds_select_node == nullptr) {
+            std::cout << "Cannot find select node based on audio_embeds node: " << audio_embeds_node_name << std::endl;
             return {};
         }
         // Check if input_ids_select_node and audio_embeds_select_node are the same node, if not, return empty.
         if (input_ids_select_node->get_friendly_name() != audio_embeds_select_node->get_friendly_name()) {
+            std::cout << "The select node based on input_ids and audio_embeds are different, input_ids_select_node: "
+                      << input_ids_select_node->get_friendly_name()
+                      << ", audio_embeds_select_node: " << audio_embeds_select_node->get_friendly_name() << std::endl;
             return {};
         }
     }
@@ -220,12 +241,15 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         // DFS search for the gather node.
         gather_node = dfs_search_gather_node(input_ids_node, 5);
         if (gather_node == nullptr) {
+            std::cout << "Cannot find gather node based on input_ids node: " << input_ids_node_name << std::endl;
             return {};
         }
 
         // Create a new model with gather node as output and input_ids node as input.
         ov::ResultVector results{std::make_shared<ov::op::v0::Result>(gather_node->output(0))};
-        auto text_embed_model = std::make_shared<ov::Model>(results, {input_ids_node}, "input_ids_embed_model");
+        auto text_embed_model = std::make_shared<ov::Model>(results,
+                                                            ov::ParameterVector{input_ids_node},
+                                                            "input_ids_embed_model");
         result["text_embed_model"] = text_embed_model;
     }
 
@@ -248,14 +272,13 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         }
 
         auto embedding_input = std::make_shared<ov::op::v0::Parameter>(split_node->get_element_type(),
-                                                                    split_node->get_output_partial_shape(0)));
+                                        split_node->get_output_partial_shape(0));
         new_parameters.push_back(embedding_input);
 
         // Replace split_node's output's input with embedding_input.
         for (const auto& output : split_node->outputs()) {
-            for (const auto& target_input : output.get_target_inputs()) {
-                const auto& next_node = target_input.get_node();
-                next_node->input(target_input.get_index()).replace_source_output(embedding_input->output(0));
+            for (auto target_input : output.get_target_inputs()) {
+                target_input.replace_source_output(embedding_input->output(0));
             }
         }
 
@@ -263,10 +286,10 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         // as well.
         if (input_ids_node->outputs().size() == 2) {
             for (const auto& output : input_ids_node->outputs()) {
-                for (const auto& target_input : output.get_target_inputs()) {
+                for (auto target_input : output.get_target_inputs()) {
                     const auto& next_node = target_input.get_node();
                     if (next_node->get_type_name() == std::string("ShapeOf")) {
-                        next_node->input(target_input.get_index()).replace_source_output(embedding_input->output(0));
+                        target_input.replace_source_output(embedding_input->output(0));
                     }
                 }
             }

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -164,6 +164,7 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
     auto text_embedding_input = std::make_shared<ov::op::v0::Parameter>(gather_node->get_element_type(),
                                                                         gather_node->get_output_partial_shape(0));
     text_embedding_input->set_friendly_name("text_embeds");
+    text_embedding_input->output(0).get_tensor().set_names({"text_embeds"});
     ov::ParameterVector new_parameters{text_embedding_input};
     // Use exact nodes referenced by split_node subgraph to avoid undeclared-parameter mismatch.
     for (const auto& parameter_node : parameters) {
@@ -197,6 +198,7 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
     // split_node's output as new model's output.
     auto merged_embeds = std::make_shared<ov::op::v0::Result>(split_node->output(0));
     merged_embeds->set_friendly_name("merged_embeds");
+    merged_embeds->output(0).get_tensor().set_names({"merged_embeds"});
     auto merged_ebmeds_model =
         std::make_shared<ov::Model>(ov::ResultVector{merged_embeds}, new_parameters, "embedding_merge_model");
     auto detached_merged_embeds = merged_ebmeds_model->clone();
@@ -276,6 +278,7 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         // Create a new model with gather node as output and input_ids node as input.
         auto text_embeds = std::make_shared<ov::op::v0::Result>(gather_node->output(0));
         text_embeds->set_friendly_name("text_embeds");
+        text_embeds->output(0).get_tensor().set_names({"text_embeds"});
         auto text_embeds_model = std::make_shared<ov::Model>(ov::ResultVector{text_embeds},
                                                             ov::ParameterVector{input_ids_node},
                                                             "input_ids_embed_model");
@@ -315,26 +318,27 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
             new_parameters.push_back(parameter);
         }
 
-        auto input_embeds = std::make_shared<ov::op::v0::Parameter>(split_node->get_element_type(),
-                                        split_node->get_output_partial_shape(0));
-        input_embeds->set_friendly_name("input_embeds");
-        new_parameters.push_back(input_embeds);
+        auto merged_embeds_input = std::make_shared<ov::op::v0::Parameter>(split_node->get_element_type(),
+                                split_node->get_output_partial_shape(0));
+        merged_embeds_input->set_friendly_name("merged_embeds");
+        merged_embeds_input->output(0).get_tensor().set_names({"merged_embeds"});
+        new_parameters.push_back(merged_embeds_input);
 
-        // Replace split_node's output's input with input_embeds.
+        // Replace split_node's output's input with merged_embeds_input.
         for (const auto& output : split_node->outputs()) {
             for (auto target_input : output.get_target_inputs()) {
-                target_input.replace_source_output(input_embeds->output(0));
+                target_input.replace_source_output(merged_embeds_input->output(0));
             }
         }
 
-        // If input_ids_node have 2 outputs, the one is shapeof node, replace shapeof node's input with input_embeds
+        // If input_ids_node have 2 outputs, the one is shapeof node, replace shapeof node's input with merged_embeds_input
         // as well.
         if (input_ids_node->outputs().size() == 2) {
             for (const auto& output : input_ids_node->outputs()) {
                 for (auto target_input : output.get_target_inputs()) {
                     const auto& next_node = target_input.get_node();
                     if (next_node->get_type_name() == std::string("ShapeOf")) {
-                        target_input.replace_source_output(input_embeds->output(0));
+                        target_input.replace_source_output(merged_embeds_input->output(0));
                     }
                 }
             }

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -143,7 +143,6 @@ std::set<std::shared_ptr<ov::Node>> find_parameters(const std::shared_ptr<ov::No
 std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_model,
                                                       std::shared_ptr<ov::Node> split_node,
                                                       std::shared_ptr<ov::Node> input_ids_node,
-                                                      const std::set<std::shared_ptr<ov::Node>>& parameters,
                                                       const std::shared_ptr<ov::Node>& gather_node) {
     OPENVINO_ASSERT(gather_node != nullptr, "find_embedding_merge_model: gather_node is null");
     OPENVINO_ASSERT(split_node != nullptr, "find_embedding_merge_model: split_node is null");
@@ -154,15 +153,12 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
                                                                         gather_node->get_output_partial_shape(0));
     text_embedding_input->set_friendly_name("text_embedding_input");
     ov::ParameterVector new_parameters{text_embedding_input};
-    for (const auto& parameter : parameters) {
+    // Keep all original parameters except input_ids to preserve graph dependencies.
+    for (const auto& parameter : original_model.get_parameters()) {
         if (parameter->get_friendly_name() == input_ids_node->get_friendly_name()) {
             continue;
         }
-        auto parameter_node = ov::as_type_ptr<ov::op::v0::Parameter>(parameter);
-        OPENVINO_ASSERT(parameter_node != nullptr,
-                        "find_embedding_merge_model: non-Parameter node in parameter set: ",
-                        parameter->get_friendly_name());
-        new_parameters.push_back(parameter_node);
+        new_parameters.push_back(parameter);
     }
 
     // replace gather_node output consumers with text_embedding_input.
@@ -172,9 +168,16 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
         }
     }
 
+    // Debug: show all parameters of the new model.
+    std::cout << "New model parameters: " << std::endl;
+    for (const auto& parameter : new_parameters) {
+        std::cout << " - Parameter name: " << parameter->get_friendly_name() << std::endl;
+    }
+
     // split_node's output as new model's output.
     ov::ResultVector new_results{std::make_shared<ov::op::v0::Result>(split_node->output(0))};
     auto embedding_merge_model = std::make_shared<ov::Model>(new_results, new_parameters, "embedding_merge_model");
+    ov::serialize(embedding_merge_model, "embedding_merge_model.xml", "embedding_merge_model.bin");
     return embedding_merge_model;
 }
 
@@ -251,8 +254,7 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
     }
 
     // Find merger model.
-    auto embedding_merge_model =
-        find_embedding_merge_model(original_model, split_node, input_ids_node, parameters, gather_node);
+    auto embedding_merge_model = find_embedding_merge_model(original_model, split_node, input_ids_node, gather_node);
     result["embedding_merge_model"] = embedding_merge_model;
 
     // Get LLM model with embedding input.

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -6,6 +6,9 @@ namespace ov::genai::modeling::samples {
 
 // DFS search for the selece node.
 std::shared_ptr<ov::Node> dfs_search_select_node(const std::shared_ptr<ov::Node>& current_node, int max_search_depth) {
+    if (current_node == nullptr) {
+        return nullptr;
+    }
     if (max_search_depth < 0) {
         return nullptr;
     }
@@ -28,6 +31,9 @@ std::shared_ptr<ov::Node> dfs_search_select_node(const std::shared_ptr<ov::Node>
 }
 
 std::shared_ptr<ov::Node> dfs_search_gather_node(const std::shared_ptr<ov::Node>& current_node, int max_search_depth) {
+    if (current_node == nullptr) {
+        return nullptr;
+    }
     if (max_search_depth < 0) {
         std::cout << "DFS search gather node reach max search depth, current node: " << current_node->get_friendly_name() << std::endl;
         return nullptr;
@@ -96,6 +102,9 @@ std::shared_ptr<ov::Node> find_last_select_node(std::shared_ptr<ov::Node> select
 // less than 10, to avoid wrong split point from other branches.
 std::shared_ptr<ov::Node> search_split_point(const std::shared_ptr<ov::Node>& input_node,
                                              const int max_search_depth = 10) {
+    if (input_node == nullptr) {
+        return nullptr;
+    }
     // Step 1: DFS search for the select node with the expected pattern
     auto select_node = dfs_search_select_node(input_node, max_search_depth);
     if (select_node == nullptr) {
@@ -267,16 +276,16 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         // Create a new model with gather node as output and input_ids node as input.
         auto text_embeds = std::make_shared<ov::op::v0::Result>(gather_node->output(0));
         text_embeds->set_friendly_name("text_embeds");
-        auto text_embed_model = std::make_shared<ov::Model>(ov::ResultVector{text_embeds},
+        auto text_embeds_model = std::make_shared<ov::Model>(ov::ResultVector{text_embeds},
                                                             ov::ParameterVector{input_ids_node},
                                                             "input_ids_embed_model");
-        result["text_embed_model"] = text_embed_model;
+        result["text_embeds_model"] = text_embeds_model;
     }
 
     // Find merger model.
-    auto merged_embeds_model =
+    auto merge_embeds_model =
         find_embedding_merge_model(original_model, split_node, input_ids_node, parameters, gather_node);
-    result["merged_embeds_model"] = merged_embeds_model;
+    result["merge_embeds_model"] = merge_embeds_model;
 
     // Get LLM model from original model(exclude embedding merge part, and text embedding part).
     {
@@ -294,12 +303,12 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
             // Skip model(embedding_merge_model)'s parameters, if the parameter only has one child node,
             // as they will be moved to the new embedding merge model.
             bool parameter_only_one_output = parameter->output(0).get_target_inputs().size() == 1u;
-            bool parameter_in_merged_embeds_model = std::find_if(merged_embeds_model->get_parameters().begin(),
-                                                                 merged_embeds_model->get_parameters().end(),
+            bool parameter_in_merged_embeds_model = std::find_if(merge_embeds_model->get_parameters().begin(),
+                                                                 merge_embeds_model->get_parameters().end(),
                                                                  [&parameter](const std::shared_ptr<ov::op::v0::Parameter>& merged_embeds_parameter) {
                                                                      return parameter->get_friendly_name() ==
                                                                             merged_embeds_parameter->get_friendly_name();
-                                                                 }) != merged_embeds_model->get_parameters().end();
+                                                                 }) != merge_embeds_model->get_parameters().end();
             if (parameter_only_one_output && parameter_in_merged_embeds_model) {
                 continue;
             }

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -350,7 +350,10 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         //     std::cout << " - Parameter name: " << parameter->get_friendly_name() << std::endl;
         // }
 
-        auto llm_model = std::make_shared<ov::Model>(original_model.get_results(), new_parameters, "llm_model");
+        auto llm_model = std::make_shared<ov::Model>(original_model.get_results(),
+                                                     original_model.get_sinks(),
+                                                     new_parameters,
+                                                     "llm_model");
         result["llm_model"] = llm_model;
     }
 

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -1,0 +1,281 @@
+#include "split_text_model.hpp"
+
+namespace ov::genai::modeling::samples {
+
+// DFS search for the selece node.
+std::shared_ptr<ov::Node> dfs_search_select_node(const std::shared_ptr<ov::Node>& current_node, int max_search_depth) {
+    if (max_search_depth < 0) {
+        return nullptr;
+    }
+    // Name is not fix, just check the type is "Select"
+    if (current_node->get_type_name() == std::string("Select")) {
+        return current_node;
+    }
+    for (const auto& output : current_node->outputs()) {
+        for (const auto& target_input : output.get_target_inputs()) {
+            const auto& next_node = target_input.get_node();
+            auto result = dfs_search_select_node(next_node, max_search_depth - 1);
+            if (result != nullptr) {
+                return result;
+            }
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<ov::Node> dfs_search_gather_node(const std::shared_ptr<ov::Node>& current_node, int max_search_depth) {
+    if (max_search_depth < 0) {
+        return nullptr;
+    }
+    // Name is not fix, just check the type is "Gather"
+    if (current_node->get_type_name() == std::string("Gather")) {
+        return current_node;
+    }
+    // Towards parent node searching
+    for (const auto& input : current_node->inputs()) {
+        const auto& next_node = input.get_source_output().get_node();
+        auto result = dfs_search_gather_node(next_node, max_search_depth - 1);
+        if (result != nullptr) {
+            return result;
+        }
+    }
+}
+return nullptr;
+}
+
+std::shared_ptr<ov::Node> find_parameter_node_by_name(const ov::Model& model, const std::string& parameter_name) {
+    std::shared_ptr<ov::Node> parameter_node = nullptr;
+    model.get_parameters().for_each([&](const ov::Output<const ov::Node>& parameter) {
+        if (parameter.get_node()->get_friendly_name() == parameter_name) {
+            parameter_node = parameter.get_node_shared_ptr();
+        }
+    });
+    return parameter_node;
+}
+
+// Get last "select" node.
+// For example: select node1 -> select node2 -> select node3, return select node3 as the split point.
+std::shared_ptr<ov::Node> find_last_select_node(std::shared_ptr<ov::Node> select_node) {
+    std::shared_ptr<ov::Node> last_select_node = select_node;
+    while (true) {
+        bool found_next_select = false;
+        for (const auto& output : last_select_node->outputs()) {
+            for (const auto& target_input : output.get_target_inputs()) {
+                const auto& next_node = target_input.get_node();
+                if (next_node->get_type_name() == std::string("Select")) {
+                    last_select_node = next_node;
+                    found_next_select = true;
+                    break;
+                }
+            }
+            if (found_next_select) {
+                break;
+            }
+        }
+        if (!found_next_select) {
+            break;
+        }
+    }
+    return last_select_node;
+}
+
+// Automatic split point finding can be implemented by analyzing the original model graph,  and finding the node
+// that matches the expected pattern. Pattern 1: Type is select node, if exists 2 neighbors select node, choose the
+// last one as the split point. Pattern 2: Inputs: [input_ids, visual_embeds/audio_embeds], the 3 inputs should link
+// to the same select node. Pattern 3: If "input_ids" has 2 sons in the graph, if one of the sons is a "shapeof"
+// node. The "gather" node should be between the other son and the select node. Pattern 4: Search max deep should be
+// less than 10, to avoid wrong split point from other branches.
+std::shared_ptr<ov::Node> search_split_point(const ov::Model& original_model,
+                                             const std::shared_ptr<ov::Node>& input_node,
+                                             const int max_search_depth = 10) {
+    // Step 1: DFS search for the select node with the expected pattern
+    auto select_node = dfs_search_select_node(input_node, max_search_depth);
+    auto last_select_node = find_last_select_node(select_node);
+
+    return last_select_node;
+}
+
+// Find all parameters node of the split node. From the split node, traverse the graph backward to find all parameters
+// nodes. To avoid duplicate nodes, use a set to store the visited nodes.
+// For example:
+// A   B       C
+//  \ /        |
+//  select1  gather
+//    |   /
+//  select2
+// From this graph, if split node is select2, the parameters nodes are A, B and C. If split node is select1, the
+// parameters nodes are A and B.
+std::set<std::shared_ptr<ov::Node>> find_parameters(const std::shared_ptr<ov::Node>& node) {
+    std::set<std::shared_ptr<ov::Node>> parameters;
+    std::set<std::shared_ptr<ov::Node>> visited;
+    std::vector<std::shared_ptr<ov::Node>> stack;
+    stack.push_back(node);
+    while (!stack.empty()) {
+        auto current_node = stack.back();
+        stack.pop_back();
+        if (visited.count(current_node) > 0) {
+            continue;
+        }
+        visited.insert(current_node);
+        if (current_node->get_type_name() == std::string("Parameter")) {
+            parameters.insert(current_node);
+        }
+        for (const auto& input : current_node->inputs()) {
+            const auto& next_node = input.get_source_output().get_node();
+            stack.push_back(next_node);
+        }
+    }
+    return parameters;
+}
+
+// Get embedding merge model.
+// Inputs: input text embedding, visual embedding and audio embedding.
+// Output: merged embedding.
+std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_model,
+                                                      std::shared_ptr<ov::Node> split_node,
+                                                      std::shared_ptr<ov::Node> input_ids_node,
+                                                      const std::set<std::shared_ptr<ov::Node>>& parameters,
+                                                      const std::shared_ptr<ov::Node>& gather_node) {
+    OPENVINO_ASSERT(gather_node != nullptr, "find_embedding_merge_model: gather_node is null");
+    OPENVINO_ASSERT(split_node != nullptr, "find_embedding_merge_model: split_node is null");
+    OPENVINO_ASSERT(input_ids_node != nullptr, "find_embedding_merge_model: input_ids_node is null");
+
+    // gather_node's output as new model's input.
+    auto text_embedding_input = std::make_shared<ov::op::v0::Parameter>(gather_node->get_element_type(),
+                                                                        gather_node->get_output_partial_shape(0));
+    ov::ParameterVector new_parameters{text_embedding_input};
+    for (const auto& parameter : parameters) {
+        if (parameter->get_friendly_name() == input_ids_node->get_friendly_name()) {
+            continue;
+        }
+        new_parameters.push_back(std::make_shared<ov::op::v0::Parameter>(parameter->get_element_type(),
+                                                                         parameter->get_output_partial_shape(0)));
+    }
+
+    // replace gather_node->output->input to text_embedding_input, only need replace current edge.
+    for (const auto& output : gather_node->outputs()) {
+        for (const auto& target_input : output.get_target_inputs()) {
+            const auto& next_node = target_input.get_node();
+            if (next_node->get_friendly_name() != gather_node->get_friendly_name()) {
+                continue;
+            }
+            next_node->input(target_input.get_index()).replace_source_output(text_embedding_input->output(0));
+        }
+    }
+
+    // split_node's output as new model's output.
+    ov::ResultVector new_results{std::make_shared<ov::op::v0::Result>(split_node->output(0))};
+    auto embedding_merge_model = std::make_shared<ov::Model>(new_results, new_parameters, "embedding_merge_model");
+    return embedding_merge_model;
+}
+
+// Split ov::model into text embed model, embedding merge model, and LLM model with embedding input.
+std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Model& original_model,
+                                                                   const std::string& input_ids_node_name,
+                                                                   const std::string& visual_embeds_node_name,
+                                                                   const std::string& audio_embeds_node_name) {
+    std::map<std::string, std::shared_ptr<ov::Model>> result;
+
+    // Find split point based on input_ids.
+    auto input_ids_node = find_parameter_node_by_name(original_model, input_ids_node_name);
+    auto input_ids_select_node = search_split_point(original_model, input_ids_node, 10);
+    if (input_ids_select_node == nullptr) {
+        return {};
+    }
+
+    // Find split point based on visual_embeds.
+    if (!visual_embeds_node_name.empty()) {
+        auto visual_embeds_node = find_parameter_node_by_name(original_model, visual_embeds_node_name);
+        auto visual_embeds_select_node = dfs_search_select_node(visual_embeds_node, 5);
+        if (visual_embeds_select_node == nullptr) {
+            return {};
+        }
+        // Check if input_ids_select_node and visual_embeds_select_node are the same node, if not, return empty.
+        if (input_ids_select_node->get_friendly_name() != visual_embeds_select_node->get_friendly_name()) {
+            return {};
+        }
+    }
+
+    // Find split point based on audio_embeds.
+    if (!audio_embeds_node_name.empty()) {
+        auto audio_embeds_node = find_parameter_node_by_name(original_model, audio_embeds_node_name);
+        auto audio_embeds_select_node = dfs_search_select_node(audio_embeds_node, 5);
+        if (audio_embeds_select_node == nullptr) {
+            return {};
+        }
+        // Check if input_ids_select_node and audio_embeds_select_node are the same node, if not, return empty.
+        if (input_ids_select_node->get_friendly_name() != audio_embeds_select_node->get_friendly_name()) {
+            return {};
+        }
+    }
+
+    auto split_node = input_ids_select_node;
+
+    // Find all parameters of the split node.
+    auto parameters = find_parameters(split_node);
+
+    // Find text embed model.
+    std::shared_ptr<ov::Node> gather_node = nullptr;
+    {
+        // DFS search for the gather node.
+        gather_node = dfs_search_gather_node(input_ids_node, 5);
+        if (gather_node == nullptr) {
+            return {};
+        }
+
+        // Create a new model with gather node as output and input_ids node as input.
+        ov::ResultVector results{std::make_shared<ov::op::v0::Result>(gather_node->output(0))};
+        auto text_embed_model = std::make_shared<ov::Model>(results, {input_ids_node}, "input_ids_embed_model");
+        result["text_embed_model"] = text_embed_model;
+    }
+
+    // Find merger model.
+    auto embedding_merge_model =
+        find_embedding_merge_model(original_model, split_node, input_ids_node, parameters, gather_node);
+    result["embedding_merge_model"] = embedding_merge_model;
+
+    // Get LLM model with embedding input.
+    {
+        // Replace original model's input with split node's output, and replace original model's output with split
+        // node's output.
+        ov::ParameterVector new_parameters;
+        for (const auto& parameter : original_model.get_parameters()) {
+            if (parameter->get_friendly_name() == input_ids_node->get_friendly_name()) {
+                continue;
+            }
+            new_parameters.push_back(std::make_shared<ov::op::v0::Parameter>(parameter->get_element_type(),
+                                                                             parameter->get_output_partial_shape(0)));
+        }
+
+        auto embedding_input = std::make_shared<ov::op::v0::Parameter>(split_node->get_element_type(),
+                                                                    split_node->get_output_partial_shape(0)));
+        new_parameters.push_back(embedding_input);
+
+        // Replace split_node's output's input with embedding_input.
+        for (const auto& output : split_node->outputs()) {
+            for (const auto& target_input : output.get_target_inputs()) {
+                const auto& next_node = target_input.get_node();
+                next_node->input(target_input.get_index()).replace_source_output(embedding_input->output(0));
+            }
+        }
+
+        // If input_ids_node have 2 outputs, the one is shapeof node, replace shapeof node's input with embedding_input
+        // as well.
+        if (input_ids_node->outputs().size() == 2) {
+            for (const auto& output : input_ids_node->outputs()) {
+                for (const auto& target_input : output.get_target_inputs()) {
+                    const auto& next_node = target_input.get_node();
+                    if (next_node->get_type_name() == std::string("ShapeOf")) {
+                        next_node->input(target_input.get_index()).replace_source_output(embedding_input->output(0));
+                    }
+                }
+            }
+        }
+
+        auto llm_model = std::make_shared<ov::Model>(original_model.get_results(), new_parameters, "llm_model");
+        result["llm_model"] = llm_model;
+    }
+
+    return result;
+}
+}  // namespace ov::genai::modeling::samples

--- a/src/cpp/src/modeling/samples/utils/split_text_model.cpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.cpp
@@ -168,24 +168,36 @@ std::shared_ptr<ov::Model> find_embedding_merge_model(const ov::Model& original_
         new_parameters.push_back(parameter);
     }
 
-    // replace gather_node output consumers with text_embedding_input.
+    // Temporarily replace gather_node output consumers with text_embedding_input.
+    std::vector<ov::Input<ov::Node>> gather_consumers;
     for (const auto& output : gather_node->outputs()) {
         for (auto target_input : output.get_target_inputs()) {
-            target_input.replace_source_output(text_embedding_input->output(0));
+            gather_consumers.push_back(target_input);
         }
+    }
+    for (auto& target_input : gather_consumers) {
+        target_input.replace_source_output(text_embedding_input->output(0));
     }
 
     // Debug: show all parameters of the new model.
-    std::cout << "New model parameters: " << std::endl;
-    for (const auto& parameter : new_parameters) {
-        std::cout << " - Parameter name: " << parameter->get_friendly_name() << std::endl;
-    }
+    // std::cout << "New model parameters: " << std::endl;
+    // for (const auto& parameter : new_parameters) {
+    //     std::cout << " - Parameter name: " << parameter->get_friendly_name() << std::endl;
+    // }
 
     // split_node's output as new model's output.
-    ov::ResultVector new_results{std::make_shared<ov::op::v0::Result>(split_node->output(0))};
-    auto embedding_merge_model = std::make_shared<ov::Model>(new_results, new_parameters, "embedding_merge_model");
-    ov::serialize(embedding_merge_model, "embedding_merge_model.xml", "embedding_merge_model.bin");
-    return embedding_merge_model;
+    auto merged_embeds = std::make_shared<ov::op::v0::Result>(split_node->output(0));
+    merged_embeds->set_friendly_name("merged_embeds");
+    auto merged_ebmeds_model =
+        std::make_shared<ov::Model>(ov::ResultVector{merged_embeds}, new_parameters, "embedding_merge_model");
+    auto detached_merged_embeds = merged_ebmeds_model->clone();
+
+    // Restore original graph edges to avoid introducing undeclared text_embeds into llm model construction.
+    for (auto& target_input : gather_consumers) {
+        target_input.replace_source_output(gather_node->output(0));
+    }
+
+    return detached_merged_embeds;
 }
 
 // Split ov::model into text embed model, embedding merge model, and LLM model with embedding input.
@@ -253,61 +265,77 @@ std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Mod
         }
 
         // Create a new model with gather node as output and input_ids node as input.
-        ov::ResultVector results{std::make_shared<ov::op::v0::Result>(gather_node->output(0))};
-        auto text_embed_model = std::make_shared<ov::Model>(results,
+        auto text_embeds = std::make_shared<ov::op::v0::Result>(gather_node->output(0));
+        text_embeds->set_friendly_name("text_embeds");
+        auto text_embed_model = std::make_shared<ov::Model>(ov::ResultVector{text_embeds},
                                                             ov::ParameterVector{input_ids_node},
                                                             "input_ids_embed_model");
-        ov::serialize(text_embed_model, "text_embed_model.xml", "text_embed_model.bin");
         result["text_embed_model"] = text_embed_model;
     }
 
     // Find merger model.
-    auto embedding_merge_model =
+    auto merged_embeds_model =
         find_embedding_merge_model(original_model, split_node, input_ids_node, parameters, gather_node);
-    result["embedding_merge_model"] = embedding_merge_model;
+    result["merged_embeds_model"] = merged_embeds_model;
 
-    // Get LLM model with embedding input.
+    // Get LLM model from original model(exclude embedding merge part, and text embedding part).
     {
-        // Replace original model's input with split node's output, and replace original model's output with split
-        // node's output.
+        // Get new parameters for the LLM model. It includes all parameters in the original model except the parameters
+        // in the embedding merge model and the input_ids parameter. And add a new parameter as the input of the LLM
+        // model, which is the output of the embedding merge model.
         ov::ParameterVector new_parameters;
-        const auto& embedding_merge_parameters = embedding_merge_model->get_parameters();
+
         for (const auto& parameter : original_model.get_parameters()) {
-            // Skip input_ids node, as it will be replaced by the embedding input. To preserve graph dependencies, keep all other original parameters.
+            // Skip input_ids node, as it will be replaced by the embedding input.
             if (parameter->get_friendly_name() == input_ids_node->get_friendly_name()) {
                 continue;
             }
-            // Skip Model(embedding_merge_model)'s parameters, as they will be replaced by the embedding input.
-            if (std::find(embedding_merge_parameters.begin(), embedding_merge_parameters.end(), parameter) !=
-                embedding_merge_parameters.end()) {
+
+            // Skip model(embedding_merge_model)'s parameters, if the parameter only has one child node,
+            // as they will be moved to the new embedding merge model.
+            bool parameter_only_one_output = parameter->output(0).get_target_inputs().size() == 1u;
+            bool parameter_in_merged_embeds_model = std::find_if(merged_embeds_model->get_parameters().begin(),
+                                                                 merged_embeds_model->get_parameters().end(),
+                                                                 [&parameter](const std::shared_ptr<ov::op::v0::Parameter>& merged_embeds_parameter) {
+                                                                     return parameter->get_friendly_name() ==
+                                                                            merged_embeds_parameter->get_friendly_name();
+                                                                 }) != merged_embeds_model->get_parameters().end();
+            if (parameter_only_one_output && parameter_in_merged_embeds_model) {
                 continue;
             }
             new_parameters.push_back(parameter);
         }
 
-        auto embedding_input = std::make_shared<ov::op::v0::Parameter>(split_node->get_element_type(),
+        auto input_embeds = std::make_shared<ov::op::v0::Parameter>(split_node->get_element_type(),
                                         split_node->get_output_partial_shape(0));
-        new_parameters.push_back(embedding_input);
+        input_embeds->set_friendly_name("input_embeds");
+        new_parameters.push_back(input_embeds);
 
-        // Replace split_node's output's input with embedding_input.
+        // Replace split_node's output's input with input_embeds.
         for (const auto& output : split_node->outputs()) {
             for (auto target_input : output.get_target_inputs()) {
-                target_input.replace_source_output(embedding_input->output(0));
+                target_input.replace_source_output(input_embeds->output(0));
             }
         }
 
-        // If input_ids_node have 2 outputs, the one is shapeof node, replace shapeof node's input with embedding_input
+        // If input_ids_node have 2 outputs, the one is shapeof node, replace shapeof node's input with input_embeds
         // as well.
         if (input_ids_node->outputs().size() == 2) {
             for (const auto& output : input_ids_node->outputs()) {
                 for (auto target_input : output.get_target_inputs()) {
                     const auto& next_node = target_input.get_node();
                     if (next_node->get_type_name() == std::string("ShapeOf")) {
-                        target_input.replace_source_output(embedding_input->output(0));
+                        target_input.replace_source_output(input_embeds->output(0));
                     }
                 }
             }
         }
+
+        // Debug: show all parameters of the new model.
+        // std::cout << "LLM model parameters: " << std::endl;
+        // for (const auto& parameter : new_parameters) {
+        //     std::cout << " - Parameter name: " << parameter->get_friendly_name() << std::endl;
+        // }
 
         auto llm_model = std::make_shared<ov::Model>(original_model.get_results(), new_parameters, "llm_model");
         result["llm_model"] = llm_model;

--- a/src/cpp/src/modeling/samples/utils/split_text_model.hpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace ov::genai::modeling::samples {
+
+// Helper function to split text ov model into multiple sub-models.
+// For example, for a text model with input: [input_ids, visual_embeds, or audio_embeds] and output: [logits], we can
+// split it into 3 sub-models:
+//  - Sub-model 1: input_ids -> text_embeds
+//  - Sub-model 2: text_embeds + visual_embeds/audio_embeds -> merged_embeds
+//  - Sub-model 3: merged_embeds -> logits
+// This function will take the original model and the split points, and return the sub-models with submodel's names.
+// The split points can be defined by the user, or can be automatically determined by analyzing the model graph.
+// The sub-models can then be used for more flexible inference, such as pre-computing text embeddings, or fusing
+// visual/audio embeddings at different stages. Parameters:
+// Parameters:
+//  - original_model: the original ov model to be split.
+//  - input_ids_node_name: the name of the input node for input_ids, which is used to find the text embedding branch in the graph.
+//  - visual_embeds_node_name: the name of the input node for visual_embeds, which is used to find the visual embedding branch in the graph. It can be empty if the model does not have visual embeddings.
+//  - audio_embeds_node_name: the name of the input node for audio_embeds, which is used to find the audio embedding branch in the graph. It can be empty if the model does not have audio embeddings.
+std::map<std::string, std::shared_ptr<ov::Model>> split_text_model(const ov::Model& original_model,
+                                                                   const std::string& input_ids_node_name,
+                                                                   const std::string& visual_embeds_node_name = std::string(),
+                                                                   const std::string& audio_embeds_node_name = std::string());
+}  // namespace ov::genai::modeling::samples

--- a/src/cpp/src/modeling/samples/utils/split_text_model.hpp
+++ b/src/cpp/src/modeling/samples/utils/split_text_model.hpp
@@ -2,7 +2,10 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
+
+#include <openvino/openvino.hpp>
 
 namespace ov::genai::modeling::samples {
 

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/md_llm_inference_sdpa.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/md_llm_inference_sdpa.cpp
@@ -42,7 +42,7 @@ const ModuleSpec& LLMInferenceSDPAModule::get_spec() {
         s.add_input("rope_delta", {DataType::OVTensor}, true);
         s.add_input("visual_embeds", {DataType::OVTensor}, true);
         s.add_input("visual_pos_mask", {DataType::OVTensor}, true);
-        s.add_input("grid_thw", {DataType::OVTensor}, true);
+        s.add_input("grid_thw", {DataType::OVTensor, DataType::VecOVTensor}, true);
         s.add_input("deepstack_embeds", {DataType::VecOVTensor}, true);
         s.add_input("audio_embeds", {DataType::OVTensor}, true);
         s.add_input("audio_pos_mask", {DataType::OVTensor}, true);

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
@@ -12,10 +12,18 @@
 
 #include "modeling_private/models/qwen3_omni/processing_qwen3_omni.hpp"
 #include "modeling/models/qwen3_vl/processing_qwen3_vl.hpp"
+#include "modeling/samples/utils/split_text_model.hpp"
 #include "module_genai/utils/com_utils.hpp"
 #include "module_genai/utils/profiler.hpp"
 #include "openvino/genai/chat_history.hpp"
 #include "utils.hpp"
+
+#define ENABLE_SPLIT_MODEL 1
+
+static bool g_enable_split_model = []() {
+    const char* env_var = std::getenv("ENABLE_SPLIT_MODEL");
+    return env_var != nullptr && std::string(env_var) == "1";
+}();
 
 namespace ov::genai::module {
 LLMInferenceSDPAImpl_Qwen3Omni::LLMInferenceSDPAImpl_Qwen3Omni(const IBaseModuleDesc::PTR& desc,
@@ -37,8 +45,19 @@ LLMInferenceSDPAImpl_Qwen3Omni::LLMInferenceSDPAImpl_Qwen3Omni(const IBaseModule
     }
 
     auto llm_model = ov::genai::utils::singleton_core().read_model(m_models_ir);
-    auto compiled_model = ov::genai::utils::singleton_core().compile_model(llm_model, m_device, properties);
-    m_infer_request = compiled_model.create_infer_request();
+    if (g_enable_split_model) {
+        GENAI_INFO("Splitting original model into text_embed_model, merge_embed_model, and llm_model for better performance with Qwen3-Omni.");
+        auto splited_models = modeling::samples::split_text_model(*llm_model, "input_ids", "visual_embeds", "audio_embeds");
+        auto compiled_model_text_embeds = ov::genai::utils::singleton_core().compile_model(splited_models["text_embed_model"], m_device, properties);
+        m_infer_request_text_embeds = compiled_model_text_embeds.create_infer_request();
+        auto compiled_model_merge_embeds = ov::genai::utils::singleton_core().compile_model(splited_models["merge_embed_model"], m_device, properties);
+        m_infer_request_merge_embeds = compiled_model_merge_embeds.create_infer_request();
+        auto compiled_model_llm = ov::genai::utils::singleton_core().compile_model(splited_models["llm_model"], m_device, properties);
+        m_infer_request_llm = compiled_model_llm.create_infer_request();
+    } else {
+        auto compiled_model = ov::genai::utils::singleton_core().compile_model(llm_model, m_device, properties);
+        m_infer_request = compiled_model.create_infer_request();
+    }
 }
 
 LLMInferenceSDPAModule::InputsParams::PTR LLMInferenceSDPAImpl_Qwen3Omni::parse_inputs(
@@ -82,17 +101,205 @@ void LLMInferenceSDPAImpl_Qwen3Omni::run() {
     prepare_inputs();
     auto inputs_params = std::dynamic_pointer_cast<InputsParamsQwen3Omni>(parse_inputs());
 
-    std::string generated_text = run_qwen3_omni_decode(inputs_params->input_ids,
-                                                       inputs_params->attention_mask,
-                                                       inputs_params->position_ids,
-                                                       inputs_params->rope_deltas,
-                                                       inputs_params->visual_embeds,
-                                                       inputs_params->visual_pos_mask,
-                                                       inputs_params->deepstack_embeds,
-                                                       inputs_params->audio_embeds,
-                                                       inputs_params->audio_pos_mask);
+    std::string generated_text;
+    if (g_enable_split_model) {
+        generated_text = run_qwen3_omni_decode_split_models(inputs_params->input_ids,
+                                                            inputs_params->attention_mask,
+                                                            inputs_params->position_ids,
+                                                            inputs_params->rope_deltas,
+                                                            inputs_params->visual_embeds,
+                                                            inputs_params->visual_pos_mask,
+                                                            inputs_params->deepstack_embeds,
+                                                            inputs_params->audio_embeds,
+                                                            inputs_params->audio_pos_mask);
+    } else {
+        generated_text = run_qwen3_omni_decode(inputs_params->input_ids,
+                                               inputs_params->attention_mask,
+                                               inputs_params->position_ids,
+                                               inputs_params->rope_deltas,
+                                               inputs_params->visual_embeds,
+                                               inputs_params->visual_pos_mask,
+                                               inputs_params->deepstack_embeds,
+                                               inputs_params->audio_embeds,
+                                               inputs_params->audio_pos_mask);
+    }
     GENAI_INFO("LLM output: " + generated_text);
     this->outputs["generated_text"].data = generated_text;
+}
+
+std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode_split_models(
+    const ov::Tensor& input_ids,
+    const ov::Tensor& attention_mask,
+    const ov::Tensor& position_ids,
+    const ov::Tensor& rope_deltas,
+    const std::optional<ov::Tensor>& visual_embeds,
+    const std::optional<ov::Tensor>& visual_pos_mask,
+    const std::optional<std::vector<ov::Tensor>>& deepstack_embeds,
+    const std::optional<ov::Tensor>& audio_embeds,
+    const std::optional<ov::Tensor>& audio_pos_mask) {
+    using TIO = ov::genai::modeling::models::Qwen3OmniTextIO;
+    const auto& model_config = m_model_config;
+
+    const size_t batch = input_ids.get_shape()[0];
+    const int64_t prompt_len = static_cast<int64_t>(input_ids.get_shape()[1]);
+}
+
+ov::Tensor LLMInferenceSDPAImpl_Qwen3Omni::infer_text_embeds(const ov::Tensor& input_ids) {
+    using TIO = ov::genai::modeling::models::Qwen3OmniTextIO;
+    const auto& model_config = m_model_config;
+
+    m_infer_request_text_embeds.set_tensor(TIO::kInputIds, input_ids);
+    m_infer_request_text_embeds.infer();
+    auto text_embeds = m_infer_request_text_embeds.get_tensor("text_embeds");
+    return text_embeds;
+}
+
+ov::Tensor LLMInferenceSDPAImpl_Qwen3Omni::infer_merge_embeds(const ov::Tensor& text_embeds,
+                                                              const ov::Tensor& visual_embeds,
+                                                              const ov::Tensor& visual_pos_mask,
+                                                              const ov::Tensor& audio_embeds,
+                                                              const ov::Tensor& audio_pos_mask) {
+    using TIO = ov::genai::modeling::models::Qwen3OmniTextIO;
+    const auto& model_config = m_model_config;
+
+    m_infer_request_merge_embeds.set_tensor("text_embeds", text_embeds);
+    m_infer_request_merge_embeds.set_tensor(TIO::kVisualEmbeds, visual_embeds);
+    m_infer_request_merge_embeds.set_tensor(TIO::kVisualPosMask, visual_pos_mask);
+    m_infer_request_merge_embeds.set_tensor(TIO::kAudioFeatures, audio_embeds);
+    m_infer_request_merge_embeds.set_tensor(TIO::kAudioPosMask, audio_pos_mask);
+    m_infer_request_merge_embeds.infer();
+    auto merge_embeds = m_infer_request_merge_embeds.get_tensor("merged_embeds");
+    return merge_embeds;
+}
+
+int64_t LLMInferenceSDPAImpl_Qwen3Omni::infer_llm(const ov::Tensor& merged_embeds,
+                                                  const ov::Tensor& attention_mask,
+                                                  const ov::Tensor& position_ids,
+                                                  const ov::Tensor& beam_idx,
+                                                  const ov::Tensor& visual_pos_mask,
+                                                  const std::vector<ov::Tensor>& deepstack_embeds) {
+    using TIO = ov::genai::modeling::models::Qwen3OmniTextIO;
+    const auto& model_config = m_model_config;
+
+    m_infer_request_llm.set_tensor("merged_embeds", merged_embeds);
+    m_infer_request_llm.set_tensor(TIO::kAttentionMask, attention_mask);
+    m_infer_request_llm.set_tensor(TIO::kPositionIds, position_ids);
+    m_infer_request_llm.set_tensor(TIO::kBeamIdx, beam_idx);
+    m_infer_request_llm.set_tensor(TIO::kVisualPosMask, visual_pos_mask);
+    for (size_t i = 0; i < deepstack_embeds.size(); i++) {
+        const std::string name = std::string(ov::genai::modeling::models::Qwen3OmniVisionIO::kDeepstackEmbedsPrefix) +
+                                 "." + std::to_string(i);
+        m_infer_request_llm.set_tensor(name, deepstack_embeds[i]);
+    }
+    m_infer_request_llm.infer();
+    auto logits = m_infer_request_llm.get_tensor(TIO::kLogits);
+    return LLMInferenceSDPAModule_Utils::argmax_last(logits);
+}
+
+int64_t LLMInferenceSDPAImpl_Qwen3Omni::llm_prefill(const ov::Tensor& input_ids,
+                                                    const ov::Tensor& attention_mask,
+                                                    const ov::Tensor& position_ids,
+                                                    const ov::Tensor& rope_deltas,
+                                                    const std::optional<ov::Tensor>& visual_embeds,
+                                                    const std::optional<ov::Tensor>& visual_pos_mask,
+                                                    const std::optional<std::vector<ov::Tensor>>& deepstack_embeds,
+                                                    const std::optional<ov::Tensor>& audio_embeds,
+                                                    const std::optional<ov::Tensor>& audio_pos_mask) {
+    using TIO = ov::genai::modeling::models::Qwen3OmniTextIO;
+    const auto& model_config = m_model_config;
+
+    const size_t batch = input_ids.get_shape()[0];
+    const int64_t prompt_len = static_cast<int64_t>(input_ids.get_shape()[1]);
+
+    auto beam_idx = LLMInferenceSDPAModule_Utils::make_beam_idx(batch);
+    m_infer_request.reset_state();
+
+    int64_t next_id = 0;
+    auto t1 = std::chrono::steady_clock::now();
+
+    auto real_visual_embeds =
+        visual_embeds.has_value()
+            ? visual_embeds.value()
+            : LLMInferenceSDPAModule_Utils::make_zeros(
+                  ov::element::f32,
+                  {batch, static_cast<size_t>(prompt_len), static_cast<size_t>(model_config.thinker.text.hidden_size)});
+    auto real_visual_pos_mask =
+        visual_pos_mask.has_value()
+            ? visual_pos_mask.value()
+            : LLMInferenceSDPAModule_Utils::make_zeros(ov::element::boolean, {batch, static_cast<size_t>(prompt_len)});
+    auto real_audio_embeds =
+        audio_embeds.has_value()
+            ? audio_embeds.value()
+            : LLMInferenceSDPAModule_Utils::make_zeros(
+                  ov::element::f32,
+                  {batch, static_cast<size_t>(prompt_len), static_cast<size_t>(model_config.thinker.text.hidden_size)});
+    auto real_audio_pos_mask =
+        audio_pos_mask.has_value()
+            ? audio_pos_mask.value()
+            : LLMInferenceSDPAModule_Utils::make_zeros(ov::element::boolean, {batch, static_cast<size_t>(prompt_len)});
+
+    // --- Prefill ---
+    if (m_splitted_model) {
+        auto text_embeds = infer_text_embeds(input_ids);
+        auto merged_embeds = infer_merge_embeds(text_embeds,
+                                                real_visual_embeds,
+                                                real_visual_pos_mask,
+                                                real_audio_embeds,
+                                                real_audio_pos_mask);
+        next_id = infer_llm(merged_embeds,
+                            attention_mask,
+                            position_ids,
+                            beam_idx,
+                            visual_pos_mask.value_or(
+                                LLMInferenceSDPAModule_Utils::make_zeros(ov::element::boolean,
+                                                                         {batch, static_cast<size_t>(prompt_len)})),
+                            deepstack_embeds.has_value() ? deepstack_embeds.value() : std::vector<ov::Tensor>{});
+    } else {
+        m_infer_request.set_tensor(TIO::kInputIds, input_ids);
+        m_infer_request.set_tensor(TIO::kAttentionMask, attention_mask);
+        m_infer_request.set_tensor(TIO::kPositionIds, position_ids);
+        m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
+        m_infer_request.set_tensor(TIO::kVisualEmbeds, real_visual_embeds);
+        m_infer_request.set_tensor(TIO::kVisualPosMask, real_visual_pos_mask);
+
+        if (deepstack_embeds.has_value()) {
+            for (size_t i = 0; i < deepstack_embeds->size(); i++) {
+                const std::string name =
+                    std::string(ov::genai::modeling::models::Qwen3OmniVisionIO::kDeepstackEmbedsPrefix) + "." +
+                    std::to_string(i);
+                m_infer_request.set_tensor(name, deepstack_embeds.value()[i]);
+            }
+        } else {
+            for (size_t i = 0; i < model_config.thinker.vision.deepstack_visual_indexes.size(); i++) {
+                const std::string name =
+                    std::string(ov::genai::modeling::models::Qwen3OmniVisionIO::kDeepstackEmbedsPrefix) + "." +
+                    std::to_string(i);
+                m_infer_request.set_tensor(name,
+                                           LLMInferenceSDPAModule_Utils::make_zeros(
+                                               ov::element::f32,
+                                               {batch,
+                                                static_cast<size_t>(prompt_len),
+                                                static_cast<size_t>(model_config.thinker.text.hidden_size)}));
+            }
+        }
+
+        m_infer_request.set_tensor(TIO::kAudioFeatures, real_audio_embeds);
+        m_infer_request.set_tensor(TIO::kAudioPosMask, real_audio_pos_mask);
+
+        const auto t_prefill0 = std::chrono::steady_clock::now();
+        {
+            PROFILE(pm, "LLMInferenceSDPAModule::run_text_decode prefill infer");
+            m_infer_request.infer();
+        }
+        next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
+    }
+
+    if (LLMInferenceSDPAModule_Utils::dump_performance_enabled()) {
+        auto t2 = std::chrono::steady_clock::now();
+        m_ttft_ms = LLMInferenceSDPAModule_Utils::elapsed_ms(t1, t2);
+    }
+
+    return next_id;
 }
 
 std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
@@ -112,67 +319,17 @@ std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
     const int64_t prompt_len = static_cast<int64_t>(input_ids.get_shape()[1]);
 
     auto beam_idx = LLMInferenceSDPAModule_Utils::make_beam_idx(batch);
-    m_infer_request.reset_state();
 
     // --- Prefill ---
-    m_infer_request.set_tensor(TIO::kInputIds, input_ids);
-    m_infer_request.set_tensor(TIO::kAttentionMask, attention_mask);
-    m_infer_request.set_tensor(TIO::kPositionIds, position_ids);
-    m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
-    if (visual_embeds.has_value() && visual_pos_mask.has_value()) {
-        m_infer_request.set_tensor(TIO::kVisualEmbeds, visual_embeds.value());
-        m_infer_request.set_tensor(TIO::kVisualPosMask, visual_pos_mask.value());
-    } else {
-        m_infer_request.set_tensor(
-            TIO::kVisualEmbeds,
-            LLMInferenceSDPAModule_Utils::make_zeros(
-                ov::element::f32,
-                {batch, static_cast<size_t>(prompt_len), static_cast<size_t>(model_config.thinker.text.hidden_size)}));
-        m_infer_request.set_tensor(
-            TIO::kVisualPosMask,
-            LLMInferenceSDPAModule_Utils::make_zeros(ov::element::boolean, {batch, static_cast<size_t>(prompt_len)}));
-    }
-    if (deepstack_embeds.has_value()) {
-        for (size_t i = 0; i < deepstack_embeds->size(); i++) {
-            const std::string name =
-                std::string(ov::genai::modeling::models::Qwen3OmniVisionIO::kDeepstackEmbedsPrefix) + "." +
-                std::to_string(i);
-            m_infer_request.set_tensor(name, deepstack_embeds.value()[i]);
-        }
-    } else {
-        for (size_t i = 0; i < model_config.thinker.vision.deepstack_visual_indexes.size(); i++) {
-            const std::string name =
-                std::string(ov::genai::modeling::models::Qwen3OmniVisionIO::kDeepstackEmbedsPrefix) + "." +
-                std::to_string(i);
-            m_infer_request.set_tensor(
-                name,
-                LLMInferenceSDPAModule_Utils::make_zeros(ov::element::f32,
-                                                         {batch,
-                                                          static_cast<size_t>(prompt_len),
-                                                          static_cast<size_t>(model_config.thinker.text.hidden_size)}));
-        }
-    }
-    if (audio_embeds.has_value() && audio_pos_mask.has_value()) {
-        m_infer_request.set_tensor(TIO::kAudioFeatures, audio_embeds.value());
-        m_infer_request.set_tensor(TIO::kAudioPosMask, audio_pos_mask.value());
-    } else {
-        ov::Tensor prefill_audio_features(
-            ov::element::f32,
-            {batch, input_ids.get_shape()[1], static_cast<size_t>(model_config.thinker.text.hidden_size)});
-        std::memset(prefill_audio_features.data(), 0, prefill_audio_features.get_byte_size());
-        m_infer_request.set_tensor(TIO::kAudioFeatures, prefill_audio_features);
-        ov::Tensor prefill_audio_pos_mask(ov::element::boolean, {batch, input_ids.get_shape()[1]});
-        std::memset(prefill_audio_pos_mask.data(), 0, prefill_audio_pos_mask.get_byte_size());
-        m_infer_request.set_tensor(TIO::kAudioPosMask, prefill_audio_pos_mask);
-    }
-
-    const auto t_prefill0 = std::chrono::steady_clock::now();
-    {
-        PROFILE(pm, "LLMInferenceSDPAModule::run_text_decode prefill infer");
-        m_infer_request.infer();
-    }
-    const auto t_prefill1 = std::chrono::steady_clock::now();
-    int64_t next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
+    auto next_id = llm_prefill(input_ids,
+                               attention_mask,
+                               position_ids,
+                               rope_deltas,
+                               visual_embeds,
+                               visual_pos_mask,
+                               deepstack_embeds,
+                               audio_embeds,
+                               audio_pos_mask);
 
     // --- Decode loop ---
     std::vector<int64_t> generated{next_id};
@@ -212,26 +369,35 @@ std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
         ov::Tensor pos =
             ov::genai::modeling::models::Qwen3OmniInputPlanner::build_decode_position_ids(rope_deltas, past_len, 1);
 
-        m_infer_request.set_tensor(TIO::kInputIds, step_ids);
-        m_infer_request.set_tensor(TIO::kAttentionMask, step_mask);
-        m_infer_request.set_tensor(TIO::kPositionIds, pos);
-        m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
-        m_infer_request.set_tensor(TIO::kVisualEmbeds, dec_vis);
-        m_infer_request.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
-        m_infer_request.set_tensor(TIO::kAudioFeatures, decode_audio_features);
-        m_infer_request.set_tensor(TIO::kAudioPosMask, decode_audio_pos_mask);
-        for (size_t i = 0; i < decode_deepstack.size(); ++i) {
-            const std::string name = std::string(ov::genai::modeling::models::Qwen3VLTextIO::kDeepstackEmbedsPrefix) +
-                                     "." + std::to_string(i);
-            m_infer_request.set_tensor(name, decode_deepstack[i]);
-        }
+        if (m_splitted_model) {
+            auto text_embeds = infer_text_embeds(step_ids);
+            auto merged_embeds =
+                infer_merge_embeds(text_embeds, dec_vis, dec_vis_mask, decode_audio_features, decode_audio_pos_mask);
+            next_id = infer_llm(merged_embeds, step_mask, pos, beam_idx, dec_vis_mask, decode_deepstack);
+        } else {
+            // Fallback to original model for decoding step if split models are not used.
+            m_infer_request.set_tensor(TIO::kInputIds, step_ids);
+            m_infer_request.set_tensor(TIO::kAttentionMask, step_mask);
+            m_infer_request.set_tensor(TIO::kPositionIds, pos);
+            m_infer_request.set_tensor(TIO::kBeamIdx, beam_idx);
+            m_infer_request.set_tensor(TIO::kVisualEmbeds, dec_vis);
+            m_infer_request.set_tensor(TIO::kVisualPosMask, dec_vis_mask);
+            m_infer_request.set_tensor(TIO::kAudioFeatures, decode_audio_features);
+            m_infer_request.set_tensor(TIO::kAudioPosMask, decode_audio_pos_mask);
+            for (size_t i = 0; i < decode_deepstack.size(); ++i) {
+                const std::string name =
+                    std::string(ov::genai::modeling::models::Qwen3VLTextIO::kDeepstackEmbedsPrefix) + "." +
+                    std::to_string(i);
+                m_infer_request.set_tensor(name, decode_deepstack[i]);
+            }
 
-        {
-            PROFILE(pm, "LLMInferenceSDPAModule::run_qwen3_omni_decode step infer");
-            m_infer_request.infer();
-        }
+            {
+                PROFILE(pm, "LLMInferenceSDPAModule::run_qwen3_omni_decode step infer");
+                m_infer_request.infer();
+            }
 
-        next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
+            next_id = LLMInferenceSDPAModule_Utils::argmax_last(m_infer_request.get_tensor(TIO::kLogits));
+        }
         generated.push_back(next_id);
         ++decode_steps;
         ++past_len;
@@ -240,7 +406,7 @@ std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
     const auto t_dec1 = std::chrono::steady_clock::now();
 
     if (LLMInferenceSDPAModule_Utils::dump_performance_enabled()) {
-        const double ttft_ms = LLMInferenceSDPAModule_Utils::elapsed_ms(m_generate_start_time, t_prefill1);
+        const double ttft_ms = m_ttft_ms;
         const double decode_ms = LLMInferenceSDPAModule_Utils::elapsed_ms(t_dec0, t_dec1);
         const double tpot_ms = decode_steps > 0 ? decode_ms / static_cast<double>(decode_steps) : 0.0;
         const double throughput =

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
@@ -20,7 +20,7 @@
 
 #define ENABLE_SPLIT_MODEL 1
 
-static bool g_enable_split_model = []() {
+static bool g_enable_split_text_llm_model = []() {
     const char* env_var = std::getenv("ENABLE_SPLIT_MODEL");
     return env_var != nullptr && std::string(env_var) == "1";
 }();
@@ -45,7 +45,7 @@ LLMInferenceSDPAImpl_Qwen3Omni::LLMInferenceSDPAImpl_Qwen3Omni(const IBaseModule
     }
 
     auto llm_model = ov::genai::utils::singleton_core().read_model(m_models_ir);
-    if (g_enable_split_model) {
+    if (g_enable_split_text_llm_model) {
         GENAI_INFO("Splitting original model into text_embeds_model, merge_embed_model, and llm_model for better performance with Qwen3-Omni.");
         auto splited_models = modeling::samples::split_text_model(*llm_model, "input_ids", "visual_embeds", "audio_features");
         auto compiled_model_text_embeds = ov::genai::utils::singleton_core().compile_model(splited_models["text_embeds_model"], m_device, properties);
@@ -101,47 +101,17 @@ void LLMInferenceSDPAImpl_Qwen3Omni::run() {
     prepare_inputs();
     auto inputs_params = std::dynamic_pointer_cast<InputsParamsQwen3Omni>(parse_inputs());
 
-    std::string generated_text;
-    if (g_enable_split_model) {
-        generated_text = run_qwen3_omni_decode_split_models(inputs_params->input_ids,
-                                                            inputs_params->attention_mask,
-                                                            inputs_params->position_ids,
-                                                            inputs_params->rope_deltas,
-                                                            inputs_params->visual_embeds,
-                                                            inputs_params->visual_pos_mask,
-                                                            inputs_params->deepstack_embeds,
-                                                            inputs_params->audio_embeds,
-                                                            inputs_params->audio_pos_mask);
-    } else {
-        generated_text = run_qwen3_omni_decode(inputs_params->input_ids,
-                                               inputs_params->attention_mask,
-                                               inputs_params->position_ids,
-                                               inputs_params->rope_deltas,
-                                               inputs_params->visual_embeds,
-                                               inputs_params->visual_pos_mask,
-                                               inputs_params->deepstack_embeds,
-                                               inputs_params->audio_embeds,
-                                               inputs_params->audio_pos_mask);
-    }
+    std::string generated_text = run_qwen3_omni_decode(inputs_params->input_ids,
+                                                       inputs_params->attention_mask,
+                                                       inputs_params->position_ids,
+                                                       inputs_params->rope_deltas,
+                                                       inputs_params->visual_embeds,
+                                                       inputs_params->visual_pos_mask,
+                                                       inputs_params->deepstack_embeds,
+                                                       inputs_params->audio_embeds,
+                                                       inputs_params->audio_pos_mask);
     GENAI_INFO("LLM output: " + generated_text);
     this->outputs["generated_text"].data = generated_text;
-}
-
-std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode_split_models(
-    const ov::Tensor& input_ids,
-    const ov::Tensor& attention_mask,
-    const ov::Tensor& position_ids,
-    const ov::Tensor& rope_deltas,
-    const std::optional<ov::Tensor>& visual_embeds,
-    const std::optional<ov::Tensor>& visual_pos_mask,
-    const std::optional<std::vector<ov::Tensor>>& deepstack_embeds,
-    const std::optional<ov::Tensor>& audio_embeds,
-    const std::optional<ov::Tensor>& audio_pos_mask) {
-    using TIO = ov::genai::modeling::models::Qwen3OmniTextIO;
-    const auto& model_config = m_model_config;
-
-    const size_t batch = input_ids.get_shape()[0];
-    const int64_t prompt_len = static_cast<int64_t>(input_ids.get_shape()[1]);
 }
 
 ov::Tensor LLMInferenceSDPAImpl_Qwen3Omni::infer_text_embeds(const ov::Tensor& input_ids) {
@@ -212,7 +182,13 @@ int64_t LLMInferenceSDPAImpl_Qwen3Omni::llm_prefill(const ov::Tensor& input_ids,
     const int64_t prompt_len = static_cast<int64_t>(input_ids.get_shape()[1]);
 
     auto beam_idx = LLMInferenceSDPAModule_Utils::make_beam_idx(batch);
-    m_infer_request.reset_state();
+    if (g_enable_split_text_llm_model) {
+        m_infer_request_text_embeds.reset_state();
+        m_infer_request_merge_embeds.reset_state();
+        m_infer_request_llm.reset_state();
+    } else {
+        m_infer_request.reset_state();
+    }
 
     int64_t next_id = 0;
     auto t1 = std::chrono::steady_clock::now();
@@ -239,7 +215,7 @@ int64_t LLMInferenceSDPAImpl_Qwen3Omni::llm_prefill(const ov::Tensor& input_ids,
             : LLMInferenceSDPAModule_Utils::make_zeros(ov::element::boolean, {batch, static_cast<size_t>(prompt_len)});
 
     // --- Prefill ---
-    if (m_splitted_model) {
+    if (g_enable_split_text_llm_model) {
         auto text_embeds = infer_text_embeds(input_ids);
         auto merged_embeds = infer_merge_embeds(text_embeds,
                                                 real_visual_embeds,
@@ -369,7 +345,7 @@ std::string LLMInferenceSDPAImpl_Qwen3Omni::run_qwen3_omni_decode(
         ov::Tensor pos =
             ov::genai::modeling::models::Qwen3OmniInputPlanner::build_decode_position_ids(rope_deltas, past_len, 1);
 
-        if (m_splitted_model) {
+        if (g_enable_split_text_llm_model) {
             auto text_embeds = infer_text_embeds(step_ids);
             auto merged_embeds =
                 infer_merge_embeds(text_embeds, dec_vis, dec_vis_mask, decode_audio_features, decode_audio_pos_mask);

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
@@ -46,11 +46,11 @@ LLMInferenceSDPAImpl_Qwen3Omni::LLMInferenceSDPAImpl_Qwen3Omni(const IBaseModule
 
     auto llm_model = ov::genai::utils::singleton_core().read_model(m_models_ir);
     if (g_enable_split_model) {
-        GENAI_INFO("Splitting original model into text_embed_model, merge_embed_model, and llm_model for better performance with Qwen3-Omni.");
-        auto splited_models = modeling::samples::split_text_model(*llm_model, "input_ids", "visual_embeds", "audio_embeds");
-        auto compiled_model_text_embeds = ov::genai::utils::singleton_core().compile_model(splited_models["text_embed_model"], m_device, properties);
+        GENAI_INFO("Splitting original model into text_embeds_model, merge_embed_model, and llm_model for better performance with Qwen3-Omni.");
+        auto splited_models = modeling::samples::split_text_model(*llm_model, "input_ids", "visual_embeds", "audio_features");
+        auto compiled_model_text_embeds = ov::genai::utils::singleton_core().compile_model(splited_models["text_embeds_model"], m_device, properties);
         m_infer_request_text_embeds = compiled_model_text_embeds.create_infer_request();
-        auto compiled_model_merge_embeds = ov::genai::utils::singleton_core().compile_model(splited_models["merge_embed_model"], m_device, properties);
+        auto compiled_model_merge_embeds = ov::genai::utils::singleton_core().compile_model(splited_models["merge_embeds_model"], m_device, properties);
         m_infer_request_merge_embeds = compiled_model_merge_embeds.create_infer_request();
         auto compiled_model_llm = ov::genai::utils::singleton_core().compile_model(splited_models["llm_model"], m_device, properties);
         m_infer_request_llm = compiled_model_llm.create_infer_request();

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.cpp
@@ -116,12 +116,10 @@ void LLMInferenceSDPAImpl_Qwen3Omni::run() {
 
 ov::Tensor LLMInferenceSDPAImpl_Qwen3Omni::infer_text_embeds(const ov::Tensor& input_ids) {
     using TIO = ov::genai::modeling::models::Qwen3OmniTextIO;
-    const auto& model_config = m_model_config;
 
     m_infer_request_text_embeds.set_tensor(TIO::kInputIds, input_ids);
     m_infer_request_text_embeds.infer();
-    auto text_embeds = m_infer_request_text_embeds.get_tensor("text_embeds");
-    return text_embeds;
+    return m_infer_request_text_embeds.get_output_tensor(0);
 }
 
 ov::Tensor LLMInferenceSDPAImpl_Qwen3Omni::infer_merge_embeds(const ov::Tensor& text_embeds,
@@ -130,7 +128,6 @@ ov::Tensor LLMInferenceSDPAImpl_Qwen3Omni::infer_merge_embeds(const ov::Tensor& 
                                                               const ov::Tensor& audio_embeds,
                                                               const ov::Tensor& audio_pos_mask) {
     using TIO = ov::genai::modeling::models::Qwen3OmniTextIO;
-    const auto& model_config = m_model_config;
 
     m_infer_request_merge_embeds.set_tensor("text_embeds", text_embeds);
     m_infer_request_merge_embeds.set_tensor(TIO::kVisualEmbeds, visual_embeds);
@@ -138,8 +135,7 @@ ov::Tensor LLMInferenceSDPAImpl_Qwen3Omni::infer_merge_embeds(const ov::Tensor& 
     m_infer_request_merge_embeds.set_tensor(TIO::kAudioFeatures, audio_embeds);
     m_infer_request_merge_embeds.set_tensor(TIO::kAudioPosMask, audio_pos_mask);
     m_infer_request_merge_embeds.infer();
-    auto merge_embeds = m_infer_request_merge_embeds.get_tensor("merged_embeds");
-    return merge_embeds;
+    return m_infer_request_merge_embeds.get_output_tensor(0);
 }
 
 int64_t LLMInferenceSDPAImpl_Qwen3Omni::infer_llm(const ov::Tensor& merged_embeds,

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.hpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.hpp
@@ -80,15 +80,6 @@ protected:
     ov::InferRequest m_infer_request_text_embeds;
     ov::InferRequest m_infer_request_merge_embeds;
     ov::InferRequest m_infer_request_llm;
-    std::string run_qwen3_omni_decode_split_models(const ov::Tensor& input_ids,
-                                      const ov::Tensor& attention_mask,
-                                      const ov::Tensor& position_ids,
-                                      const ov::Tensor& rope_deltas,
-                                      const std::optional<ov::Tensor>& visual_embeds = std::nullopt,
-                                      const std::optional<ov::Tensor>& visual_pos_mask = std::nullopt,
-                                      const std::optional<std::vector<ov::Tensor>>& deepstack_embeds = std::nullopt,
-                                      const std::optional<ov::Tensor>& audio_embeds = std::nullopt,
-                                      const std::optional<ov::Tensor>& audio_pos_mask = std::nullopt);
 };
 
 }  // namespace ov::genai::module

--- a/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.hpp
+++ b/src/cpp/src/module_genai/modules/md_llm_inference_sdpa/models/qwen3_omni.hpp
@@ -41,7 +41,46 @@ protected:
     };
     InputsParams::PTR parse_inputs(InputsParams::PTR inputs_params = nullptr) override;
 
+    double m_ttft_ms = 0.0;
+    int64_t llm_prefill(const ov::Tensor& input_ids,
+                        const ov::Tensor& attention_mask,
+                        const ov::Tensor& position_ids,
+                        const ov::Tensor& rope_deltas,
+                        const std::optional<ov::Tensor>& visual_embeds,
+                        const std::optional<ov::Tensor>& visual_pos_mask,
+                        const std::optional<std::vector<ov::Tensor>>& deepstack_embeds,
+                        const std::optional<ov::Tensor>& audio_embeds,
+                        const std::optional<ov::Tensor>& audio_pos_mask);
+
+    ov::Tensor infer_text_embeds(const ov::Tensor& input_ids);
+    ov::Tensor infer_merge_embeds(const ov::Tensor& text_embeds,
+                                  const ov::Tensor& visual_embeds,
+                                  const ov::Tensor& visual_pos_mask,
+                                  const ov::Tensor& audio_embeds,
+                                  const ov::Tensor& audio_pos_mask);
+    int64_t infer_llm(const ov::Tensor& merged_embeds,
+                      const ov::Tensor& attention_mask,
+                      const ov::Tensor& position_ids,
+                      const ov::Tensor& beam_idx,
+                      const ov::Tensor& visual_pos_mask,
+                      const std::vector<ov::Tensor>& deepstack_embeds);
+
     std::string run_qwen3_omni_decode(const ov::Tensor& input_ids,
+                                      const ov::Tensor& attention_mask,
+                                      const ov::Tensor& position_ids,
+                                      const ov::Tensor& rope_deltas,
+                                      const std::optional<ov::Tensor>& visual_embeds = std::nullopt,
+                                      const std::optional<ov::Tensor>& visual_pos_mask = std::nullopt,
+                                      const std::optional<std::vector<ov::Tensor>>& deepstack_embeds = std::nullopt,
+                                      const std::optional<ov::Tensor>& audio_embeds = std::nullopt,
+                                      const std::optional<ov::Tensor>& audio_pos_mask = std::nullopt);
+
+    // Original model is split into 3 models:
+    // 1: text embeds, 2: text/vision/audio embeds merge, 3: LLM with input_embeds.
+    ov::InferRequest m_infer_request_text_embeds;
+    ov::InferRequest m_infer_request_merge_embeds;
+    ov::InferRequest m_infer_request_llm;
+    std::string run_qwen3_omni_decode_split_models(const ov::Tensor& input_ids,
                                       const ov::Tensor& attention_mask,
                                       const ov::Tensor& position_ids,
                                       const ov::Tensor& rope_deltas,


### PR DESCRIPTION
This pull request adds functionality to split a large text model into modular sub-models for more flexible inference, introduces a new utility for this purpose, and provides a test executable. It also makes a minor update to input type handling for the LLM inference module.

**Model Splitting Functionality:**

* Added a new utility (`split_text_model`) in `split_text_model.cpp`/`.hpp` that analyzes an OpenVINO model's computation graph to automatically split it into three sub-models: a text embedding model, an embedding merger model, and an LLM model. This enables precomputing embeddings and modular inference workflows. [[1]](diffhunk://#diff-bff0c7d4ecffe2a5435032bf351e66f4fbb4cd9c978d65c5abf1aceb97bf462aR1-R362) [[2]](diffhunk://#diff-2eb0a79ae85a783d2116a8b69751859de3682ce8770f15431fd1a815279425e8R1-R31)
* Integrated the new split model utility into the build system by including `split_text_model.cpp` in the main CMake source list.
* Added a test executable (`test_split_text_model`) to demonstrate and validate splitting a model, including serialization of the resulting sub-models. [[1]](diffhunk://#diff-f4302fa918c5ca6546da4411e41352743419f3d5703ed0260c4361ccebf7b2d3R30-R51) [[2]](diffhunk://#diff-402a1258b8e0cfe4a04bd965f2dd3474fa43213c71397cf37dfecf9e047cd6a0R1-R40)

**Integration and Configuration:**

* Included the new split model utility in the Qwen3 Omni model implementation and added an environment variable (`ENABLE_SPLIT_MODEL`) to control whether model splitting is enabled at runtime.

**Other Improvements:**

* Updated the `LLMInferenceSDPAModule` to allow the `grid_thw` input to accept either a single tensor or a vector of tensors, improving flexibility in input handling.